### PR TITLE
Document WriteBackpackUart commands

### DIFF
--- a/src/content/coding/using-local-skills/javascript-api.md
+++ b/src/content/coding/using-local-skills/javascript-api.md
@@ -1486,6 +1486,27 @@ Arguments
 misty.Set(string key, string value);
 ```
 
+### misty.WriteBackpackUart - ALPHA
+
+**Available for Misty II Only**
+
+Sends data to Misty's universal asynchronous receiver-transmitter (UART) serial port. Use this command to send data from Misty to an external device connected to the port.
+
+Note that Misty can also receive data a connected device sends to the UART serial port. To use this data you must subscribe to [`StringMessage`](../../using-remote-commands/websocket-reference/#stringmessage) events.
+
+```JavaScript
+misty.WriteBackpackUart(string message, [int prePause], [int postPause])
+```
+
+Arguments
+* message (string) - The data Misty sends to the UART serial port, passed as a string value.
+* prePause (integer) - Optional. The length of time in milliseconds to wait before executing this command.
+* postPause (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPause` is not used.
+
+```JavaScript
+misty.WriteBackpackUart("your-data");
+```
+
 ## Debugging
 
 <!-- misty.GetLogFile -->

--- a/src/content/coding/using-remote-commands/rest.md
+++ b/src/content/coding/using-remote-commands/rest.md
@@ -1245,3 +1245,29 @@ Parameters
 
 Return Values
 * Result (boolean) - Returns `true` if there are no errors related to this command.
+
+## Data
+
+### WriteBackpackUart - ALPHA
+
+**Available for Misty II Only**
+
+Sends data to Misty's universal asynchronous receiver-transmitter (UART) serial port. Use this command to send data from Misty to an external device connected to the port.
+
+Note that Misty can also receive data a connected device sends to the UART serial port. To use this data you must subscribe to [`StringMessage`](../../using-remote-commands/websocket-reference/#stringmessage) events.
+
+Endpoint: POST {robot-ip-address}/api/alpha/serialport
+
+Parameters
+
+* Message (string) - The data Misty sends to the UART serial port, passed as a string value.
+
+```json
+{
+  "Message": "your-data"
+}
+```
+
+Return Values
+
+* Result (boolean) - Returns `true` if no errors related to this request.


### PR DESCRIPTION
This merge adds reference docs for `misty.WriteBackpackUart` to JS API and `WriteBackpackUart` to REST API.