### PR TITLE
Remote skill tutorial & Python wrapper updates

### DIFF
--- a/src/content/coding/using-remote-commands/architecture.md
+++ b/src/content/coding/using-remote-commands/architecture.md
@@ -11,7 +11,7 @@ There are two basic types of skill architecture: remote and local.
 
 When you send "remote commands" to Misty, your code is running on an external device (say, in desktop browser or on a Raspberry Pi) and not onboard the robot. This is different from [local skills](../../../coding/using-local-skills/architecture), where you upload your code to the robot, and it runs internally on Misty.
 
-Misty’s remote command interface is based on a powerful REST API. The examples in this topic are written in JavaScript and use helper libraries to simplify making requests and subscribing to Misty’s WebSocket connections. You can also use [this Python wrapper](https://github.com/MistyCommunity/mistyPy) to send Misty commands or a REST client such as Postman.
+Misty’s remote command interface is based on a powerful REST API. The examples in this topic are written in JavaScript and use helper libraries to simplify making requests and subscribing to Misty’s WebSocket connections. You can also use the community owned [Python wrapper](https://github.com/MistyCommunity/mistyPy) or a REST client such as Postman to send Misty commands.
 
 Creating your own remote skill for Misty typically involves two things: getting data from Misty via WebSocket connections and sending commands to Misty using her API. This topic walks you through both sides of this process.
 

--- a/src/content/coding/using-remote-commands/rest.md
+++ b/src/content/coding/using-remote-commands/rest.md
@@ -7,7 +7,7 @@ order: 3
 
 # {{title}}
 
-With the REST API, you can send commands to Misty from a REST client or browser. There is also a [Python wrapper](https://github.com/MistyCommunity/mistyPy) available for the Misty REST API.
+With the REST API, you can send commands to Misty from a REST client or browser. There is also a community owned [Python wrapper](https://github.com/MistyCommunity/mistyPy) available for the Misty REST API.
 
 To create skills for Misty, you'll need to send commands to Misty and get data back from Misty. To send commands to Misty, you can call the REST API. To get live updating data back from Misty, you'll need to use a [WebSocket connection](../architecture/#subscribing-amp-unsubscribing-to-a-websocket). You can visit the [Misty Community GitHub repo](https://github.com/MistyCommunity/MistyI/tree/master/Skills) for example skills.
 

--- a/src/content/coding/using-remote-commands/tutorials.md
+++ b/src/content/coding/using-remote-commands/tutorials.md
@@ -38,7 +38,8 @@ Alternately, you can download a compressed version of the Axios library to inclu
 Within `<script>` tags in the `<body>` of your .html document, declare a constant variable `ip` and set its value to a string with your robot’s IP address. We’ll reference this variable throughout the program to send commands to Misty. 
 
 ```JavaScript
-// Declare a constant variable and set its value to a string with your robot's IP address.
+// Declare a constant variable.
+// Set its value to your robot's IP address.
 const ip = "<robotipaddress>";
 ```
 
@@ -48,7 +49,8 @@ When we send a command to change Misty’s LED color, we need to communicate wha
 Create an object called `data` to send with the POST request. Create a property for each color parameter, and set the value of each property to an integer between `0` and `255`. The RGB values in the example change Misty’s chest LED to hot pink.
 
 ```JavaScript
-// Assemble the data to send with your POST request. Set values for each RGB color property.
+// Create a data object to send with the POST request. 
+// Set values for each RGB color property.
 let data = {
     "red": 255,
     "green": 0,
@@ -63,31 +65,38 @@ Now we’re ready to write the code to send the command to Misty. We do this by 
 The REST API endpoint for the `ChangeLED` command is `http://<robotipaddress>/api/led/change`. In your code, call `axios.post()` and pass a string with this endpoint as the first parameter. Use the previously defined variable `ip` to populate the `<robotipaddress>` section of the URL. Pass the `data` object for the second parameter.
 
 ```JavaScript
-// Call axios.post(), passing the URL of the ChangeLED endpoint as the first parameter, and the payload (the data object) as the second.
+// Call axios.post(). Pass the URL of the ChangeLED 
+// endpoint as the first parameter and the data object 
+// as the second.
 axios.post("http://" + ip + "/api/led/change", data)
 ```
 
 Because Axios is promise based, we need to use a `then()` method after calling `axios.post()`. This method returns a promise and triggers a callback function if the promise is fulfilled. We pass a callback function to `then()` to interpret information from the return values of the POST call and print a message to the console about whether the request was a failure or success.
 
 ```JavaScript
+// Use a then() method after calling axios.post(). 
+// Pass in a callback function to interpret the return 
+// values of the call and to print a message to the console 
+// indicating the request's success.
 axios.post("http://" + ip + "/api/led/change", data)
-// Use then() after calling axios.post(). Pass a callback function to interpret the return values of the POST call and print a message to the console about whether the request was a failure or a success.
     .then(function (response) {
         console.log(`ChangeLED was a ${response.data[0].status}`);
-})
+    })
 ```
 
 We use a `catch()` method after `then()`, which triggers if the promise is rejected. Pass a callback function to `catch()` to print to the console any errors returned by the request.
 
 ```JavaScript
+// Use a catch() method after then(). catch() triggers 
+// if the promise is rejected. Pass a callback to catch() 
+// to print any errors to the console.
 axios.post("http://" + ip + "/api/led/change", data)
     .then(function (response) { 
-        console.log(`ChangeLED was a ${response.data[0].status}`)
-    // Use a catch() method after then(). catch() triggers if the promise is rejected. Pass a callback to catch() to print any errors returned by the request to the console.
+        console.log(`ChangeLED was a ${response.data[0].status}`);
+    })
     .catch(function (error) {
         console.log(`There was an error with the request ${error}`);
     })
-})
 ```
 
 Now we’re ready to run the program!
@@ -113,28 +122,38 @@ See the full .html document for reference.
 </head>
 <body>
     <script>
-        // Declare a constant variable and set its value to a string with your robot's IP address.
+        // Declare a constant variable.
+        // Set its value to your robot's IP address.
         const ip = "<robotipaddress>";
 
-        // Assemble the data to send with your POST request. Set values for each RGB color property.
+        // Create a data object to send with the POST request. 
+        // Set values for each RGB color property.
         let data = {
             "red": 255,
             "green": 0,
             "blue": 0
         };
 
-        // Call axios.post(), passing the URL of the ChangeLED endpoint as the first parameter, and the payload (the data object) as the second.
+        // Call axios.post(). Pass the URL of the ChangeLED 
+        // endpoint as the first parameter and the data object 
+        // as the second.
+        
+        // Use a then() method after calling axios.post(). 
+        // Pass in a callback function to interpret the return 
+        // values of the call and to print a message to the console 
+        // indicating the request's success.
+
+        // Use a catch() method after then(). catch() triggers 
+        // if the promise is rejected. Pass a callback to catch() 
+        // to print any errors to the console.
         axios.post("http://" + ip + "/api/led/change", data)
-            // Use then() after calling axios.post(). Pass a callback function to interpret the return values of the POST call and print a message to the console about whether the request was a failure or a success.
             .then(function (response) {
-                // log the result
                 console.log(`ChangeLED was a ${response.data[0].status}`);
             })
-            // Use a catch() method after then(). catch() triggers if the promise is rejected. Pass a callback to catch() to print any errors returned by the request to the console.
             .catch(function (error) {
-                // log the error
                 console.log(`There was an error with the request ${error}`);
-			});
+            });
+
     </script>
 </body>
 </html>

--- a/src/content/coding/using-remote-commands/tutorials.md
+++ b/src/content/coding/using-remote-commands/tutorials.md
@@ -137,7 +137,7 @@ See the full .html document for reference.
         // Call axios.post(). Pass the URL of the ChangeLED 
         // endpoint as the first parameter and the data object 
         // as the second.
-        
+
         // Use a then() method after calling axios.post(). 
         // Pass in a callback function to interpret the return 
         // values of the call and to print a message to the console 
@@ -199,7 +199,8 @@ To set up your project, create a new .html document. Give it a title, and includ
 Within `<script>` tags in the `<body>` of your document, declare a constant variable `ip` and set its value to a string with your robot’s IP address. We use this variable to send commands to Misty.
 
 ```JavaScript
-// Declare a constant variable and set its value to a string with your robot’s IP address.
+// Declare a constant variable and set its 
+// value to a string with your robot’s IP address.
 const ip = "<robotipaddress>";
 ```
 
@@ -208,12 +209,17 @@ const ip = "<robotipaddress>";
 Create a new instance of `LightSocket`  called `socket`. The `socket` instance takes as parameters the IP address of your robot and two optional callback functions. The first callback triggers when a connection is opened, and the second triggers when it’s closed. Pass `ip` and a function called `openCallback()` to the new instance of `LightSocket`. Below these declarations, declare the `openCallback()` function.
 
 ```JavaScript
-// Create a new instance of LightSocket called socket. Pass as arguments the ip variable and a function named openCallback.
+// Create a new instance of LightSocket called 
+// socket. Pass as arguments the ip variable and 
+// a function named openCallback.
 let socket = new LightSocket(ip, openCallback);
 
 /* COMMANDS */
 
-// Define the function passed as the callback to the new instance of LightSocket. This is the code that executes when socket opens a connection to your robot.
+// Define the function passed as the callback 
+// to the new instance of LightSocket. This is 
+// the code that executes when socket opens a 
+// connection to your robot.
 function openCallback() {
 
 }
@@ -254,7 +260,16 @@ To subscribe to the data stream from `TimeOfFlight`, call the `Subscribe()` meth
 
 ```JavaScript
 function openCallback() {
-    // Subscribe to a new event called "CenterTimeOfFlight" that returns data when "TimeOfFlight" events are triggered. Pass arguments to make sure this event returns data for the front center time-of-flight sensor every 100 milliseconds. Pass the callback function _centerTimeOfFlight() as the final argument.
+
+    // Print a message when the connection is opened.
+    console.log("socket opened");
+
+    // Subscribe to an event called CenterTimeOfFlight
+    // that returns TimeOfFlight data. Pass arguments 
+    // to make sure this event returns data for the 
+    // front center time-of-flight sensor every 100 
+    // milliseconds. Pass the callback function 
+    // _centerTimeOfFlight() as the final argument.
     socket.Subscribe("CenterTimeOfFlight", "TimeOfFlight", 100, "SensorPosition", "==", "Center", null, _centerTimeOfFlight);
 }
 ```
@@ -268,7 +283,10 @@ function openCallback() {
 
     socket.Subscribe("CenterTimeOfFlight", "TimeOfFlight", 100, "SensorPosition", "==", "Center", null, _centerTimeOfFlight);
 
-    // Subscribe to a new event called "LocomotionCommand" that returns data when Misty's angular or linear velocity changes. Pass the callback function _locomotionCommand() as the final argument.
+    // Subscribe to an event called LocomotionCommand
+    // that returns data when Misty's angular or linear 
+    // velocity changes. Pass the callback function 
+    // _locomotionCommand() as the final argument.
     socket.Subscribe("LocomotionCommand", "LocomotionCommand", null, null, null, null, null, _locomotionCommand);
 
 }
@@ -288,7 +306,7 @@ function openCallback() {
 
     socket.Subscribe("LocomotionCommand", "LocomotionCommand", null, null, null, null, null, _locomotionCommand);
 
-    // Assemble the data to send with the DriveTime command.
+    // Create a data object to send with the DriveTime command.
     let data = {
         LinearVelocity: 50,
         AngularVelocity: 0,
@@ -315,16 +333,17 @@ function openCallback() {
         TimeMS: 5000
     };
 
-    // Use axios.post() to send the data to the DriveTime REST API endpoint.
+    // Use axios.post() to send the data 
+    // to the endpoint for the DriveTime command.
     axios.post("http://" + ip + "/api/drive/time", data)
         // Use .then() to handle a successful response.
         .then(function (response) {
-            // Print the results of the DriveTime command to the console.
+            // Print the results
             console.log(`DriveTime was a ${response.data[0].status}`);
         })
-        // Use .catch() to handle errors.
+        // Use .catch() to handle errors
         .catch(function (error) {
-            // Print any errors related to the DriveTime command to the console.
+            // Print any errors
             console.log(`There was an error with the request ${error}`);
         });
 };
@@ -340,7 +359,8 @@ We define our callbacks above the section where we define our commands. Create a
 ```JavaScript
 /* CALLBACKS */
 
-// Define the callback function that is be passed when we subscribe to the CenterTimeOfFlight event.
+// Define the callback function for handling 
+// CenterTimeOfFlight event data
 let _centerTimeOfFlight = function (data) {
 
 };
@@ -350,11 +370,15 @@ When you subscribe to an event, some messages come through that don’t contain 
 
 ```JavaScript
 let _centerTimeOfFlight = function (data) {
-    // Use try and catch statements to handle exceptions and unimportant messages from the WebSocket data stream.
+    // Use try and catch statements to handle 
+    // exceptions and unimportant messages 
+    // from the WebSocket data stream.
     try {
 
     };
-    catch(e) { };
+    catch(e) { 
+
+    };
 };
 ```
 
@@ -363,9 +387,12 @@ Inside the `try` statement, instantiate a `distance` variable. `distance` stores
 ```JavaScript
 let _centerTimeOfFlight = function (data) {
     try {
-        // Instantiate a distance variable to store the value representing the distance from Misty in meters an object has been detected by her front center time-of-flight sensor. 
+        // Create a distance variable to store 
+        // the value representing the distance 
+        // from Misty in meters an object has been 
+        // detected by her front center time-of-flight sensor. 
         let distance = data.message.distanceInMeters;
-        // Log this distance to the console.
+        // Print this distance to the console.
         console.log(distance);
     };
     catch(e) { };
@@ -381,16 +408,18 @@ let _centerTimeOfFlight = function (data) {
     try {
         let distance = data.message.distanceInMeters;
         console.log(distance);
-        // Write an if statement to check if the distance is smaller than 0.2 meters.
+        // Write an if statement to check 
+        // if the distance is smaller than 0.2 meters.
         if (distance < 0.2) {
-            // If the distance is shorter than 
+            // If the istance is less than 0.2 meters, send
+            // a request to endpoint for the Stop command.  
             axios.post("http://" + ip + "/api/drive/stop")
                 .then(function (response) {
-                    // Print the results of the Stop command to the console.
+                    // Print the results
                     console.log(`Stop was a ${response.data[0].status}`);
                 })
                 .catch(function (error) {
-                    // Print errors related to the Stop command to the console.
+                    // Print any errors
                     console.log(`There was an error with the request ${error}`);
                 });
             }
@@ -409,15 +438,21 @@ The purpose of the `_locomotionCommand()` callback function is to “clean up”
 The `LocomotionCommand` event sends data whenever linear or angular velocity changes, including when Misty starts moving when the program starts. We want to unsubscribe from WebSocket connections when Misty stops **and** the value of `LinearVelocity` is `0`. Declare a function called `_locomotionCommand()`, and pass it a parameter for the `data` received by the `LocomotionCommand` WebSocket. We only want to unsubscribe when Misty stops, so we add the condition that `linearVelocity` should be `0` to an `if` statement. As with the `_centerTimeOfFlight()` callback, place this condition inside a `try` statement, and place a `catch` statement to handle exceptions at the end of the function.
 
 ```JavaScript
-// Define the callback function that is passed when we subscribe to the LocomotionCommand event.
+// Define the callback function passed in
+// the subscription to LocomotionCommand events
 let _locomotionCommand = function (data) {
-    // Use try and catch statements to handle exceptions and unimportant messages from the WebSocket data stream.
+    // Use try and catch statements to handle 
+    // exceptions and unimportant messages 
     try {
-        // Use an if statement to check if Misty has stopped moving
+        // Use an if statement to check
+        // whether Misty stopped moving
         if (data.message.linearVelocity === 0) {
+
         }
     }
-    catch(e) { }
+    catch(e) { 
+
+    }
 };
 ```
 
@@ -427,21 +462,30 @@ If `data.message.linearVelocity === 0`, the program should unsubscribe from the 
 let _locomotionCommand = function (data) {
     try {
         if (data.message.linearVelocity === 0) {
-            // Print a message to the console for debugging.
+            // Print a message to the console to aid in debugging
             console.log("LocomotionCommand received linear velocity as", data.message.linearVelocity);
-            // Unsubscribe from the CenterTimeOfFlight and LocomotionCommand events.
+            // Unsubscribe from the CenterTimeOfFlight 
+            // and LocomotionCommand events
             socket.Unsubscribe("CenterTimeOfFlight");
             socket.Unsubscribe("LocomotionCommand");                
         }
     }
-    catch(e) { }
+    catch(e) { 
+
+    }
 };
 ```
 
 At the bottom of the script, call `socket.Connect()`. When the connection is established, the `openCallback()` function executes to subscribe to WebSocket connections and send Misty a `DriveTime` command. Data received through WebSocket connections is passed to the `_centerTimeOfFlight()` and `_locomotionCommand()` callback functions.
 
 ```JavaScript
-// Open the connection to your robot. When the connection is established, the openCallback function executes to subscribe to WebSockets and send Misty a DriveTime command. Data recieved through these WebSockets is passed to the _centerTimeOfFlight() and _locomotionCommand() callback functions.
+// Open the connection to your robot. 
+// When the connection is established, 
+// the openCallback function executes 
+// to subscribe to WebSockets and send 
+// Misty a DriveTime command. Event data 
+// is passed to the _centerTimeOfFlight() and 
+// _locomotionCommand() callback functions.
 socket.Connect();
 ```
 
@@ -468,94 +512,131 @@ See the full .html document for reference.
 </head>
 <body>
 	<script>
-		// Declare a constant variable and set its value to a string with your robot’s IP address.
+		
+        // Declare a constant variable and set its 
+        // value to a string with your robot’s IP address.
 		const ip = "<robotipaddress>";
 
-        // Create a new instance of LightSocket called socket. Pass as arguments the ip variable and a function named openCallback.
+        // Create a new instance of LightSocket called 
+        // socket. Pass as arguments the ip variable and 
+        // a function named openCallback.
 		let socket = new LightSocket(ip, openCallback);
 
         /* CALLBACKS */
         
-        // Define the callback function that is passed when we subscribe to the CenterTimeOfFlight event.
+        // Define the callback function for handling 
+        // CenterTimeOfFlight event data
 		let _centerTimeOfFlight = function (data) {
 
-            // Use try and catch statements to handle exceptions and unimportant messages from the WebSocket data stream.
+            // Use try and catch statements to handle 
+            // exceptions and unimportant messages 
+            // from the WebSocket data stream.
 			try {
-                // Instantiate a distance variable to store the value representing the distance from Misty in meters an object has been detected by her front center time-of-flight sensor. 
+                // Create a distance variable to store 
+                // the value representing the distance 
+                // from Misty in meters an object has been 
+                // detected by her front center time-of-flight sensor. 
                 let distance = data.message.distanceInMeters;
-                // Log this distance to the console.
+                // Print this distance to the console.
                 console.log(distance);
                 
-                // Write an if statement to check if the distance is smaller than 0.2 meters.
+                // Write an if statement to check 
+                // if the distance is smaller than 0.2 meters.
 				if (distance < 0.2) {
-                    // If the distance is shorter than 
+                    // If the istance is less than 0.2 meters, send
+                    // a request to endpoint for the Stop command.  
 					axios.post("http://" + ip + "/api/drive/stop")
 						.then(function (response) {
-							// Print the results of the Stop command to the console.
+							// Print the results
 							console.log(`Stop was a ${response.data[0].status}`);
 						})
 						.catch(function (error) {
-							// Print errors related to the Stop command to the console.
+							// Print any errors
 							console.log(`There was an error with the request ${error}`);
 						});
 				}
             }
 			catch (e) {
+
 			}
         };
         
-        // Define the callback function that is passed when we subscribe to the LocomotionCommand event.
+        // Define the callback function passed in
+        // the subscription to LocomotionCommand events
 		let _locomotionCommand = function (data) {
-            // Use try and catch statements to handle exceptions and unimportant messages from the WebSocket data stream.
+            // Use try and catch statements to handle 
+            // exceptions and unimportant messages 
 			try {
-				// Use an if statement to check if Misty has stopped moving
+				// Use an if statement to check
+                // whether Misty stopped moving
 				if (data.message.linearVelocity === 0) {
-                    // Print a message to the console for debugging.
+                    // Print a message to the console to aid in debugging.
 					console.log("LocomotionCommand received linear velocity as", data.message.linearVelocity);
-                    // Unsubscribe from the CenterTimeOfFlight and LocomotionCommand events.
+                    // Unsubscribe from the CenterTimeOfFlight 
+                    // and LocomotionCommand events
                     socket.Unsubscribe("CenterTimeOfFlight");
 					socket.Unsubscribe("LocomotionCommand");
 				}
 			}
-			catch(e) { }
+			catch(e) { 
+
+            }
         };
         
         /* COMMANDS */
 
-        // Define the function passed as the callback to the new instance of LightSocket. This is the code that executes when socket opens a connection to your robot.
+        // Define the function passed as the callback 
+        // to the new instance of LightSocket. This is 
+        // the code that executes when socket opens a 
+        // connection to your robot.
 		function openCallback() {
 
-            // Print a message to the console when the connection is established.
-			console.log("socket opened");
-
-            // Subscribe to a new event called "CenterTimeOfFlight" that returns data when "TimeOfFlight" events are triggered. Pass arguments to make sure this event returns data for the front center time-of-flight sensor every 100 milliseconds. Pass the callback function _centerTimeOfFlight() as the final argument.
+            // Print a message when the connection is opened.
+            console.log("socket opened");
+            
+            // Subscribe to an event called CenterTimeOfFlight
+            // that returns TimeOfFlight data. Pass arguments 
+            // to make sure this event returns data for the 
+            // front center time-of-flight sensor every 100 
+            // milliseconds. Pass the callback function 
+            // _centerTimeOfFlight() as the final argument.
 			socket.Subscribe("CenterTimeOfFlight", "TimeOfFlight", 100, "SensorPosition", "==", "Center", null, _centerTimeOfFlight);
             
-            // Subscribe to a new event called "LocomotionCommand" that returns data when Misty's angular or linear velocity changes. Pass the callback function _locomotionCommand() as the final argument.
+            // Subscribe to an event called LocomotionCommand
+            // that returns data when Misty's angular or linear 
+            // velocity changes. Pass the callback function 
+            // _locomotionCommand() as the final argument.
             socket.Subscribe("LocomotionCommand", "LocomotionCommand", null, null, null, null, null, _locomotionCommand);
 
-			// Assemble the data to send with the DriveTime command.
+            // Create a data object to send with the DriveTime command.
 			let data = {
 				LinearVelocity: 50,
 				AngularVelocity: 0,
 				TimeMS: 5000
 			};
 
-            // Use axios.post() to send the data to the DriveTime REST API endpoint.
+            // Use axios.post() to send the data 
+            // to the endpoint for the DriveTime command.
             axios.post("http://" + ip + "/api/drive/time", data)
-                // Chain .then() to handle a successful response.
+                // Use .then() to handle a successful response
 				.then(function (response) {
-					// Print the results of the DriveTime command to the console.
+					// Print the results
 					console.log(`DriveTime was a ${response.data[0].status}`);
                 })
-                // Chain .catch() to handle errors.
+                //  // Use .catch() to handle errors
 				.catch(function (error) {
-					// Print any errors related to the DriveTime command to the console.
+					// Print any errors
 					console.log(`There was an error with the request ${error}`);
 				});
 		};
 
-        // Open the connection to your robot. When the connection is established, the openCallback function executes to subscribe to WebSockets and send Misty a  DriveTime command. Data recieved through these WebSockets is passed to the _centerTimeOfFlight() and _locomotionCommand() callback functions.
+        // Open the connection to your robot. 
+        // When the connection is established, 
+        // the openCallback function executes 
+        // to subscribe to WebSockets and send 
+        // Misty a DriveTime command. Event data 
+        // is passed to the _centerTimeOfFlight() and 
+        // _locomotionCommand() callback functions.
 		socket.Connect();
 	</script>
 </body>

--- a/src/content/coding/using-remote-commands/tutorials.md
+++ b/src/content/coding/using-remote-commands/tutorials.md
@@ -685,7 +685,8 @@ Within `<script>` tags in the `<body>` of your document, declare a constant vari
 
 /* GLOBALS */
 
-// Declare a constant variable and set its value to a string with your robot's IP address.
+// Declare a constant variable and set its 
+// value to a string with your robot's IP address.
 const ip = "<robotipaddress>"
 
 ```
@@ -693,13 +694,16 @@ const ip = "<robotipaddress>"
 Create a global constant called `you` and assign it to a string with your name. Initialize an additional global variable called `onList` with the value `false`. We use these variables to check and indicate whether the user (`you`) is found on Misty’s list of learned faces.
 
 ```JavaScript
-
 /* GLOBALS */
 
 const ip = "<robotipaddress>"
 
-// Create a global constant called `you` and assign it to a string with your name. Initialize an additional global variable called `onList` with the value `false`. We use these variables to check and indicate whether the user (you) is found on Misty’s list of learned faces.
+// Create a global constant called you 
+// and assign it to a string with your name. 
 const you = "<your-name>"
+
+// Initialize another variable called 
+// onList and set its value to false.
 let onList = false;
 ```
 
@@ -711,12 +715,17 @@ Beneath these global variable declarations, declare a new instance of  `LightSoc
 
 ```JavaScript
 
-// Create a new instance of LightSocket called socket. Pass as arguments the ip variable and a function named openCallback.
+// Create a new instance of LightSocket called 
+// socket. Pass as arguments the ip variable 
+// and a function named openCallback.
 let socket = new LightSocket(ip, openCallback);
 
 /* CALLBACKS */
 
-// Define the function passed as the callback to the new instance of LightSocket. This is the code that executes when socket opens a connection to your robot.
+// Define the function passed as the callback 
+// to the new instance of LightSocket. This is 
+// the code that executes when socket opens a 
+// connection to your robot.
 async function openCallback() {
 
 }
@@ -728,7 +737,8 @@ A subscription to the `ComputerVision` WebSocket may already be active if the sk
 ```JavaScript
 
 async function openCallback() {
-    // Unsubscribe from any existing ComputerVision WebSocket connections.
+    // Unsubscribe from any existing ComputerVision 
+    // WebSocket connections.
     socket.Unsubscribe("ComputerVision");
 }
 
@@ -740,7 +750,8 @@ Next, the program should pause to give Misty time to register and execute the co
 
 /* TIMEOUT */
 
-// Define a helper function called sleep that can pause code execution for a set period of time.
+// Define a helper function called sleep that 
+// can pause code execution for a period of time.
 function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -749,7 +760,9 @@ function sleep(ms) {
 
 async function openCallback() {
     socket.Unsubscribe("ComputerVision");
-    // Use sleep() to pause execution for three seconds to give Misty time to register and execute the command.
+    // Use sleep() to pause execution for 
+    // three seconds to give Misty time 
+    // to register and execute the command.
     await sleep(3000);
 }
 
@@ -762,7 +775,8 @@ async function openCallback() {
     socket.Unsubscribe("ComputerVision");
     await sleep(3000);
 
-    // Issue a GET request to the endpoint for the GetLearnedFaces command. 
+    // Issue a GET request to the endpoint 
+    // for the GetLearnedFaces command. 
     axios.get("http://" + ip + "/api/beta/faces")
 }
 ```
@@ -774,9 +788,11 @@ async function openCallback() {
     socket.Unsubscribe("ComputerVision");
     await sleep(3000);
 
-    // Use then() to pass the response to a callback function.
+    // Use then() to pass the response 
+    // to a callback function.
     axios.get("http://" + ip + "/api/beta/faces").then(function (res) {
-        // Store the list of known faces in the faceArr variable and print the list to the console.
+        // Store the list of known faces in the
+        // faceArr variable and print this list.
         let faceArr = res.data[0].result;
         console.log("Learned faces:", faceArr);
     });
@@ -794,9 +810,12 @@ async function openCallback() {
         let faceArr = res.data[0].result;
         console.log("Learned faces:", faceArr);
 
-        // Loop through each item in faceArr. Compare each item to the value stored in the you variable.
-        for (let i = 0; i < faceArr.length; i++) {
-            // If a match is found, update the value of onList to true.
+        // Loop through each item in faceArr. 
+        // Compare each item to the value stored 
+        // in the you variable.
+            for (let i = 0; i < faceArr.length; i++) {
+            // If a match is found, update 
+            // the value of onList to true.
             if (faceArr[i] === you) {
                 onList = true;
             }
@@ -810,12 +829,17 @@ At this point the program takes one of two paths. If `onList` becomes `true`, Mi
 ```JavaScript
 /* COMMANDS */
 
-// Define the function that executes if the value stored in you is on Misty's list of known faces. 
+// Define the function that executes 
+// if the value stored in you is on 
+// Misty's list of known faces. 
 function startFaceRecognition() {
 
 };
 
-// Define the function that executes to learn the user's face if the value stored in you is not on Misty's list of known faces.
+// Define the function that executes 
+// to learn the user's face if the 
+// value stored in you is not on Misty's 
+// list of known faces.
 async function startFaceTraining() {
 
 };
@@ -838,7 +862,12 @@ async function openCallback() {
             }
         }
 
-        // Subscribe to the ComputerVision WebSocket. Pass "ComputerVision" for the eventName and msgType parameters. Set debounceMs to 200, and pass a callback function named _ComputerVision for the callback parameter. There is no need to define event conditions for this data stream; pass null for all other arguments.
+        // Subscribe to the ComputerVision WebSocket. 
+        // Pass ComputerVision for the eventName and 
+        // msgType parameters. Set debounceMs to 200 
+        // and pass a callback function named _ComputerVision 
+        // for the callback parameter. Pass null for 
+        // all other arguments.
         socket.Subscribe("ComputerVision", "ComputerVision", 200, null, null, null, null, _ComputerVision);
 
     });
@@ -864,7 +893,9 @@ async function openCallback() {
 
         socket.Subscribe("ComputerVision", "ComputerVision", 200, null, null, null, null, _ComputerVision);
 
-        // Use an if...else statement to execute startFaceRecognition() if onList is true, and to execute startFaceTraining if onList is false.
+        // Use an if, else statement to execute 
+        // startFaceRecognition() if onList is true 
+        // and to execute startFaceTraining if otherwise.
         if (onList) {
             console.log("You were found on the list!");
             startFaceRecognition();
@@ -885,7 +916,10 @@ This command tells Misty to start the occipital camera so she can match the face
 
 ```JavaScript
 function startFaceRecognition() {
-    // Print a message to the console that Misty is “starting face recognition”. Then, use Axios to send a POST request to the endpoint for the StartFaceRecognition command.
+    // Print a message to the console that Misty 
+    // is “starting face recognition”. Then, use 
+    // Axios to send a POST request to the endpoint 
+    // for the StartFaceRecognition command.
     console.log("starting face recognition");   
     axios.post("http://" + ip + "/api/beta/faces/recognition/start");
 };
@@ -895,7 +929,10 @@ In `startFaceTraining()`, log a message to the console that Misty is “starting
 
 ```JavaScript
 async function startFaceTraining() {
-    // Print a message to the console that Misty is “starting face training”. Then use Axios to send a POST request to the endpoint for the StartFaceTraining command.
+    // Print a message to the console that Misty 
+    // is “starting face training”. Then use Axios 
+    // to send a POST request to the endpoint for 
+    // the StartFaceTraining command.
     console.log("starting face training");
     axios.post("http://" + ip + "/api/beta/faces/training/start", { FaceId: you });
 };
@@ -907,9 +944,12 @@ To give Misty time to learn the user’s face, use the helper function `sleep()`
 async function startFaceTraining() {
     console.log("starting face training");
     axios.post("http://" + ip + "/api/beta/faces/training/start", { FaceId: you });
-    // Give Misty time to complete the face training process. Call sleep and pass in the value 20000 for 20 seconds. 
+    // Give Misty time to complete the face 
+    // training process. Call sleep and pass 
+    // in the value 20000 for 20 seconds. 
     await sleep(20000);
-    // Print a message to the console that face training is complete.
+    // Print a message to the console that 
+    // face training is complete.
     console.log("face training complete");
 
 };
@@ -924,7 +964,8 @@ async function startFaceTraining() {
 
     await sleep(20000);
     console.log("face training complete");
-    // Use Axios to send a POST request to the endpoint for the StartFaceRecognition command.
+    // Use Axios to send a POST request to the endpoint 
+    // for the StartFaceRecognition command.
     axios.post("http://" + ip + "/api/beta/faces/recognition/start");
 };
 ```
@@ -934,13 +975,15 @@ async function startFaceTraining() {
 Data sent through the `ComputerVision` event subscription is passed to the `_ComputerVision()` callback function. As discussed in previous tutorials, WebSocket connections sometimes send registration and error messages that do not contain event data. To handle messages unrelated to `ComputerVision` events, wrap the code for the `_ComputerVision()` callback inside `try` and `catch` statements. As seen in the example, you can print caught errors to the console by passing `e` to the `catch` statement, but this is not necessary for the program to execute successfully.
 
 ```JavaScript
-// Define the callback function that is passed when we subscribe to ComputerVision events.
+// Define the callback function for handling  
+// ComputerVision event data.
 function _ComputerVision(data) { 
-    //  Wrap the code for the _ComputerVision callback inside try and catch statements to handle messages unrelated to ComputerVision events. 
+    // Wrap the code for the _ComputerVision callback 
+    // inside try and catch statements. 
     try { 
 
     }
-    // Print caught errors to the console by passing e to the catch statement.
+    // Print any errors to the console.
     catch (e) {
         console.log("Error: " + e);
     }
@@ -952,7 +995,10 @@ The `_ComputerVision()` callback triggers any time the occipital camera gathers 
 ```JavaScript
 function _ComputerVision(data) {
     try { 
-        // Use an if statement to check that personName does not equal "unknown person", null, or undefined. personName is included in the message returned by ComputerVision WebSocket events.
+        // Use an if statement to check that personName 
+        // does not equal "unknown person", null, or 
+        // undefined. personName is included in the 
+        // message returned by ComputerVision WebSocket events.
         if (data.message.personName !== "unknown person" && data.message.personName !== null && data.message.personName !== undefined) {
 
         }
@@ -971,12 +1017,14 @@ If a face is recognized, the value of the `"personName"` property is the name of
 function _ComputerVision(data) {
     try {
         if (data.message.personName !== "unknown person" && data.message.personName !== null && data.message.personName !== undefined) {
-            // If the face is recognized, print a message to greet the person by name.
+            // If the face is recognized, print a 
+            // message to greet the person by name.
             console.log(`A face was recognized. Hello there ${data.message.personName}!`);
 
             // Unsubscribe from the ComputerVision WebSocket.
             socket.Unsubscribe("ComputerVision");
-            // Use Axios to issue a POST command to the endpoint for the StopFaceRecognition command.
+            // Use Axios to issue a POST command to the 
+            // endpoint for the StopFaceRecognition command.
             axios.post("http://" + ip + "/api/beta/faces/recognition/stop");
         }
     }
@@ -989,7 +1037,16 @@ function _ComputerVision(data) {
 At the bottom of the script, call `socket.Connect()`. When the connection is established, the `openCallback()` function executes and the process begins. 
 
 ```JavaScript
-// Open the connection to your robot. When the connection is established, the openCallback function executes to check whether the value stored in you is on Misty's list of known faces. Then, the program subscribes to the ComputerVision WebSocket, and Misty either greets you by name or starts facial training to learn your face so she can greet you in the future.
+// Open the connection to your robot. 
+// When the connection is established, 
+// the openCallback function executes 
+// to check whether the value stored in 
+// you is on Misty's list of known faces. 
+// Then, the program subscribes to the 
+// ComputerVision WebSocket, and Misty 
+// either greets you by name or starts 
+// facial training to learn your face so 
+// she can greet you in the future.
 socket.Connect();
 ```
 
@@ -1018,48 +1075,79 @@ See the full .html document for reference.
 	<script>
         /* GLOBALS */
         
-        // Declare a constant variable and set its value to a string with your robot's IP address.
+        // Declare a constant variable and set its 
+        // value to a string with your robot's IP address.
         const ip = "<robotipaddress>"
-        // Create a global constant called `you` and assign it to a string with your name. Initialize an additional global variable called `onList` with the value `false`. We use these variables to check and indicate whether the user (you) is found on Misty’s list of learned faces.
+
+        // Create a global constant called you 
+        // and assign it to a string with your name. 
 		const you = "<your-name>"
+        // Initialize another variable called 
+        // onList and set its value to false.
         let onList = false;
         
-        // Create a new instance of LightSocket called socket. Pass as arguments the ip variable and a function named openCallback.
+        // Create a new instance of LightSocket called 
+        // socket. Pass as arguments the ip variable 
+        // and a function named openCallback.
 		let socket = new LightSocket(ip, openCallback);
 
         /* TIMEOUT */
-        // Define a helper function called sleep that can pause code execution for a set period of time.
+
+        // Define a helper function called sleep that 
+        // can pause code execution for a period of time.
 		function sleep(ms) {
 			return new Promise(resolve => setTimeout(resolve, ms));
 		}
 
         /* CALLBACKS */
 
-        // Define the function passed as the callback to the new instance of LightSocket. This is the code that executes when socket opens a connection to your robot.
+        // Define the function passed as the callback 
+        // to the new instance of LightSocket. This is 
+        // the code that executes when socket opens a 
+        // connection to your robot.
 		async function openCallback() {
-			// Unsubscribe from any existing ComputerVision WebSocket connections.
+
+            // Unsubscribe from any existing ComputerVision 
+            // WebSocket connections.
             socket.Unsubscribe("ComputerVision");
-            // Pause execution for three seconds to give Misty time to register and execute the command.
+
+            // Use sleep() to pause execution for 
+            // three seconds to give Misty time 
+            // to register and execute the command.
 			await sleep(3000);
 
-			// Issue a GET request to the endpoint for the GetLearnedFaces command. Use then() to pass the response to a callback function.
+            // Issue a GET request to the endpoint 
+            // for the GetLearnedFaces command. 
+            // Use then() to pass the response 
+            // to a callback function.
 			axios.get("http://" + ip + "/api/beta/faces").then(function (res) {
-				// Store the list of known faces in the faceArr variable and print the list to the console.
+                // Store the list of known faces in the
+                // faceArr variable and print this list.
 				let faceArr = res.data[0].result;
 				console.log("Learned faces:", faceArr);
 
-				// Loop through each item in faceArr. Compare each item to the value stored in the you variable.
+                // Loop through each item in faceArr. 
+                // Compare each item to the value stored 
+                // in the you variable.
 				for (let i = 0; i < faceArr.length; i++) {
-                    // If a match is found, update the value of onList to true.
+                    // If a match is found, update 
+                    // the value of onList to true.
 					if (faceArr[i] === you) {
 						onList = true;
 					}
 				}
 
-				// Subscribe to the ComputerVision WebSocket. Pass "ComputerVision" for the eventName and msgType parameters. Set debounceMs to 200, and pass a callback function named _ComputerVision for the callback parameter. There is no need to define event conditions for this data stream; pass null for all other arguments.
+                // Subscribe to the ComputerVision WebSocket. 
+                // Pass ComputerVision for the eventName and 
+                // msgType parameters. Set debounceMs to 200 
+                // and pass a callback function named _ComputerVision 
+                // for the callback parameter. Pass null for 
+                // all other arguments.
 				socket.Subscribe("ComputerVision", "ComputerVision", 200, null, null, null, null, _ComputerVision);
 
-				// Use an if...else statement to execute startFaceRecognition() if onList is true, and to execute startFaceTraining if onList is false.
+                // Use an if, else statement to execute 
+                // startFaceRecognition() if onList is true 
+                // and to execute startFaceTraining if otherwise.
 				if (onList) {
 					console.log("You were found on the list!");
 					startFaceRecognition();
@@ -1070,22 +1158,29 @@ See the full .html document for reference.
 			});
         };
         
-        // Define the callback function that is passed when we subscribe to ComputerVision events.
+        // Define the callback function for handling  
+        // ComputerVision event data.
 		function _ComputerVision(data) {
-            //  Wrap the code for the _ComputerVision callback inside try and catch statements to handle messages unrelated to ComputerVision events. 
+            // Wrap the code for the _ComputerVision callback 
+            // inside try and catch statements. 
 			try {
-                // Use an if statement to check that personName does not equal "unknown person", null, or undefined. personName is included in the message returned by ComputerVision WebSocket events.
+                // Use an if statement to check that personName 
+                // does not equal "unknown person", null, or 
+                // undefined. personName is included in the 
+                // message returned by ComputerVision WebSocket events.
 				if (data.message.personName !== "unknown person" && data.message.personName !== null && data.message.personName !== undefined) {
-					// If the face is recognized, print a message to greet the person by name.
+                    // If the face is recognized, print a 
+                    // message to greet the person by name.
 					console.log(`A face was recognized. Hello there ${data.message.personName}!`);
 
 					// Unsubscribe from the ComputerVision WebSocket.
                     socket.Unsubscribe("ComputerVision");
-                    // Use Axios to issue a POST command to the endpoint for the StopFaceRecognition command.
+                    // Use Axios to issue a POST command to the 
+                    // endpoint for the StopFaceRecognition command.
 					axios.post("http://" + ip + "/api/beta/faces/recognition/stop");
 				}
             }
-            // Print caught errors to the console by passing e to the catch statement.
+            // Print any errors to the console.
 			catch (e) {
 				console.log("Error: " + e);
 			}
@@ -1093,28 +1188,52 @@ See the full .html document for reference.
 
         /* COMMANDS */
 
-        // Define the function that executes if the value stored in you is on Misty's list of known faces. 
+        // Define the function that executes 
+        // if the value stored in you is on 
+        // Misty's list of known faces. 
 		function startFaceRecognition() {
-			// Print a message to the console that Misty is “starting face recognition". Then, use Axios to send a POST request to the endpoint for the StartFaceRecognition command.
+            // Print a message to the console that Misty 
+            // is “starting face recognition”. Then, use 
+            // Axios to send a POST request to the endpoint 
+            // for the StartFaceRecognition command.
 			console.log("starting face recognition");
 			axios.post("http://" + ip + "/api/beta/faces/recognition/start");
         };
         
-        // Define the function that executes to learn the user's face if the value stored in you is not on Misty's list of known faces.
+        // Define the function that executes 
+        // to learn the user's face if the 
+        // value stored in you is not on Misty's 
+        // list of known faces.
 		async function startFaceTraining() {
-			// Print a message to the console that Misty is “starting face training”. Then use Axios to send a POST request to the endpoint for the StartFaceTraining command.
+            // Print a message to the console that Misty 
+            // is “starting face training”. Then use Axios 
+            // to send a POST request to the endpoint for 
+            // the StartFaceTraining command.
 			console.log("starting face training");
 			axios.post("http://" + ip + "/api/beta/faces/training/start", { FaceId: you });
 
-			// Give Misty time to complete the face training process. Call sleep and pass in the value 20000 for 20 seconds. 
+            // Give Misty time to complete the face 
+            // training process. Call sleep and pass 
+            // in the value 20000 for 20 seconds. 
             await sleep(20000);
-            // Print a message to the console that face training is complete. Then, use Axios to send a POST request to the endpoint for the StartFaceRecognition command.
-			console.log("face training complete");
+            // Print a message to the console that 
+            // face training is complete.
+            console.log("face training complete");
+            // Use Axios to send a POST request to the endpoint 
+             // for the StartFaceRecognition command.
 			axios.post("http://" + ip + "/api/beta/faces/recognition/start");
         };
         
-        // Open the connection to your robot. When the connection is established, the openCallback function executes to check whether the value stored in you is on Misty's list of known faces. Then, the program subscribes to the ComputerVision WebSocket, and Misty either greets you by name or starts facial training to learn your face so she can greet you in the future.
-
+        // Open the connection to your robot. 
+        // When the connection is established, 
+        // the openCallback function executes 
+        // to check whether the value stored in 
+        // you is on Misty's list of known faces. 
+        // Then, the program subscribes to the 
+        // ComputerVision WebSocket, and Misty 
+        // either greets you by name or starts 
+        // facial training to learn your face so 
+        // she can greet you in the future.
         socket.Connect();
         
 	</script>


### PR DESCRIPTION
These changes include
* A fix for the syntax in the Change LED remote skill tutorial (a set of closing parens/brackets `})` had been bumped to the wrong line in a code sample)
* Fixes to improve the readability in code comments for several remote skill tutorials. More of this kind of cleanup is required for the remaining tutorials, but this is a start.
* Changed references to the Python wrapper to include the modifier "community owned" 