### PR TITLE
Change title to be 'Local Skill Tutorials'

### DIFF
--- a/src/content/coding/using-local-skills/tutorials.md
+++ b/src/content/coding/using-local-skills/tutorials.md
@@ -1,5 +1,5 @@
 ---
-title: Tutorials
+title: Local Skill Tutorials
 layout: coding.hbs
 columns: three
 order: 2


### PR DESCRIPTION
Placeholder for potentially fixing search for 'tutorials'

Not sure if this solves the generic search for 'Tutorials' but might make it a little easier to find the right content.