### PR TITLE
Develop

### DIFF
--- a/scripts/metalsmith.js
+++ b/scripts/metalsmith.js
@@ -162,8 +162,9 @@ exports.metalsmith = function() {
           'apps'
         ]
       }
-    }))//end of collections/sections
-		// Fix previous / next links when a page doesn't exist for a specific device
+    }))
+    //end of collections/sections
+    // Fix previous / next links when a page doesn't exist for a specific device
     .use(fixLinks({
       key: 'devices'
     }))

--- a/src/assets/less/menu.less
+++ b/src/assets/less/menu.less
@@ -144,7 +144,7 @@ ul.guide-menu {
 .menubar li {
   text-overflow: ellipsis;
   overflow-x: hidden;
-  white-space: nowrap;
+  // white-space: nowrap;
   padding: 2px 0;
 }
 

--- a/src/content/docs/reference/javascript-api.md
+++ b/src/content/docs/reference/javascript-api.md
@@ -1,5 +1,5 @@
 ---
-title: JavaScript API
+title: On-Robot JavaScript API
 layout: coding.hbs
 columns: three
 order: 1
@@ -7,7 +7,7 @@ order: 1
 
 # {{title}}
 
-Use the JavaScript API to write skills for Misty that run locally on your robot. For more about local skills, see [Local Skill Architecture](../../../docs/skills/local-skill-architecture).
+Use the JavaScript API to write skills for Misty that run locally on your robot. For more about on-robot skills, see [On-Robot JavaScript API Architecture](../../../docs/skills/local-skill-architecture).
 
 **Note:** Not all of Misty's API is equally complete. You may see some commands labeled "Beta" or "Alpha" because the related hardware, firmware, or software is still under development. Feel free to use these commands, but realize they may behave unpredictably at this time.
 
@@ -65,7 +65,7 @@ misty.DeleteImageAssetFromRobot("DeleteMe.png");
 ### misty.GetListOfImages
 Obtains a list of the images stored on Misty.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -87,7 +87,7 @@ misty.GetListOfImages();
 
 Returns
 
-* Result (array) - Returns an array containing one element for each image currently stored on Misty. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information. Each element in the array contains the following:
+* Result (array) - Returns an array containing one element for each image currently stored on Misty. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information. Each element in the array contains the following:
    * Height (integer) - The height of the image file.
    * Name (string) - The name of the image file.
    * Width (integer) - The width of the image file.
@@ -143,7 +143,7 @@ misty.ClearDisplayText();
 ### misty.GetImage - ALPHA
 Obtains a system or user-uploaded image file currently stored on Misty.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 misty.GetImage(string imageName, [bool base64 = true] [string callbackRule = "synchronous"], [string skillToCallUniqueId], [int prePause], [int postPause]);
@@ -164,7 +164,7 @@ misty.GetImage("Angry.png", true);
 
 Returns
 
-- Result (object) - An object containing image data and meta information. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+- Result (object) - An object containing image data and meta information. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
   - base64 (string) - A string containing the Base64-encoded image data.
   - format (string) - The type and format of the image returned.
   - height (integer) - The height of the image in pixels.
@@ -177,7 +177,7 @@ Provides the current distance of objects from Misty’s Occipital Structure Core
 
 **Note:** Make sure to use `misty.SlamStartStreaming()` to open the data stream from Misty's depth sensor before using this command. Mapping or tracking does not need to be active to use this command.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -198,7 +198,7 @@ misty.SlamGetDepthImage();
 
 Returns
 
-- Result (object) - An object containing depth information about the image matrix, with the following fields. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+- Result (object) - An object containing depth information about the image matrix, with the following fields. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
   - height (integer) - The height of the matrix.
   - image (array) - A matrix of size `height` x `width` containing individual values of type float. Each value is the distance in millimeters from the sensor for each pixel in the captured image. For example, if you point the sensor at a flat wall 2 meters away, most of the values in the matrix should be around 2000. Note that as the robot moves further away from a scene being viewed, each pixel value will represent a larger surface area. Conversely, if it moves closer, each pixel value will represent a smaller area.
   - width (integer) - The width of the matrix.
@@ -208,7 +208,7 @@ Takes a photo using the camera on Misty’s Occipital Structure Core depth senso
 
 **Note:** Make sure to use `misty.SlamStartStreaming()` to open the data stream from Misty's depth sensor before using this command. Mapping or tracking does not need to be active to use this command.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -230,7 +230,7 @@ misty.SlamGetVisibleImage(true);
 
 Returns
 
-- Result (object) -  An object containing image data and meta information. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+- Result (object) -  An object containing image data and meta information. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
   - base64 (string) - A string containing the Base64-encoded image data.
   - format (string) - The type and format of the image returned.
   - height (integer) - The height of the picture in pixels.
@@ -280,7 +280,7 @@ misty.SlamStopStreaming();
 
 Takes a photo with Misty’s 4K camera.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -302,7 +302,7 @@ misty.TakePicture(true);
 
 Returns
 
-* Result (object) - An object containing image data and meta information. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+* Result (object) - An object containing image data and meta information. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
    * Base64 (string) - A string containing the Base64-encoded image data.
    * Format (string) - The type and format of the image returned.
    * Height (integer) - The height of the image in pixels.
@@ -322,7 +322,7 @@ Lists the default system audio files currently stored on Misty.
 
 Note that you can use the `misty.GetListOfAudioFiles()` command to list all audio files on the robot (system files and user uploads).
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -343,7 +343,7 @@ misty.GetListOfAudioClips();
 
 Returns
 
-* Result (array) - Returns an array of audio file information. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information. Each item in the array contains the following:
+* Result (array) - Returns an array of audio file information. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information. Each item in the array contains the following:
    * Name (string) - The name of the audio file.
    * userAddedAsset (boolean) - If `true`, the audio file was added by the user. If `false`, the file is one of Misty's default audio files. **Note:** Because `misty.GetListOfAudioClips()` only returns information for default audio files, the value of this property is `false` for all items in this list.
 
@@ -351,7 +351,7 @@ Returns
 
 Lists all audio files (default system files and user-added files) currently stored on Misty.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -374,7 +374,7 @@ Returns
 
 <!-- TODO: review return values -->
 
-* Result (array) - Returns an array of audio file information. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information. Each item in the array contains the following:
+* Result (array) - Returns an array of audio file information. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information. Each item in the array contains the following:
    * Name (string) - The name of the audio file.
    * userAddedAsset (boolean) - If `true`, the file was added by the user. If `false`, the file is one of Misty's system files.
 
@@ -622,7 +622,7 @@ misty.Halt();
 ### misty.GetAvailableWifiNetworks
 Obtains a list of local WiFi networks and basic information regarding each.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 
 ```JavaScript
@@ -644,7 +644,7 @@ misty.GetAvailableWifiNetworks();
 
 Returns
 
-* Result (array) - An array containing one element for each WiFi network discovered. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information. Each element contains the following:
+* Result (array) - An array containing one element for each WiFi network discovered. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information. Each element contains the following:
    * Name (string) - The name of the WiFi network.
    * SignalStrength (integer) - A numeric value for the strength of the network.
    * IsSecure (boolean) - Returns `true` if the network is secure. Otherwise, `false`.
@@ -653,7 +653,7 @@ Returns
 ### misty.GetBatteryLevel
 Obtains Misty's current battery level.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -674,12 +674,12 @@ misty.GetBatteryLevel();
 
 Returns
 
-* Result (double) - Returns a value between 0 and 100 corresponding to the current battery level. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+* Result (double) - Returns a value between 0 and 100 corresponding to the current battery level. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
 
 ### misty.GetDeviceInformation
 Obtains device-related information for the robot.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -700,7 +700,7 @@ misty.GetDeviceInformation();
 
 Returns
 
-* Result (object) - An object containing information about the robot, with the following fields. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+* Result (object) - An object containing information about the robot, with the following fields. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
    * batteryLevel - The battery charge percentage (in decimal format) and the current battery voltage.
    * currentProfileName - The name of the network that the robot is on.
    * hardwareInfo - Hardware and firmware version information for both the Real Time Controller board and the Motor Controller board. 
@@ -717,7 +717,7 @@ Returns
 ### misty.GetHelp
 Obtains information about a specified API command. Calling `misty.GetHelp()` with no parameters returns a list of all the API commands that are available.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -739,7 +739,7 @@ misty.GetHelp();
 
 Returns
 
-* Result (string) - A string containing the requested help information. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+* Result (string) - A string containing the requested help information. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
 
 <!-- Information - BETA -->
 
@@ -747,7 +747,7 @@ Returns
 ### misty.GetBetaHelp - BETA
 Obtains information about a specified beta API command. Calling `misty.GetBetaHelp()` with no parameters returns a list of all the beta API commands that are available.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -769,7 +769,7 @@ misty.GetBetaHelp();
 
 Returns
 
-* Result (string) - A string containing the requested help information. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+* Result (string) - A string containing the requested help information. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
 
 ## LEDs
 
@@ -837,7 +837,7 @@ misty.ClearLearnedFaces();
 ### misty.GetLearnedFaces - BETA
 Obtains a list of the names of faces on which Misty has been successfully trained.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -858,7 +858,7 @@ misty.GetLearnedFaces();
 
 Returns
 
-* Result (string) - A list of the names for faces that Misty has been trained to recognize. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+* Result (string) - A list of the names for faces that Misty has been trained to recognize. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
 
 ### misty.StartFaceDetection - BETA
 Initiates Misty's detection of faces in her line of vision. This command assigns each detected face a random ID.
@@ -1031,7 +1031,7 @@ misty.SetHeadDegrees(string axis, double degrees, double velocity, [int prePause
 ```
 
 Arguments
-* axis (string) - The axis to change. Values are `"yaw"` (turn), `"pitch"` (up-and-down), or `"roll"` (tilt). Passing a value of `"yaw"` or `"roll"` in a local skill running on Misty I robots does nothing.  
+* axis (string) - The axis to change. Values are `"yaw"` (turn), `"pitch"` (up-and-down), or `"roll"` (tilt). Passing a value of `"yaw"` or `"roll"` in a skill running on Misty I robots does nothing.  
 * degrees (double) - Indicates the degree to move Misty’s head to along the given axis. The value range for pitch is -9.5 (fully up) to 35.0 (fully down); for roll, -43.0 (fully left) to 43.0 (fully right); for yaw, -90.0 (fully right) to 90.0 (fully left). Note that due to normal variations in the range of head motion available to each robot, the minimum and maximum values for your Misty may differ slightly from the values listed here. 
 * velocity (double) - The speed of the head movement. Value range: 0 to 100.
 * prePause (integer) - Optional. The length of time in milliseconds to wait before executing this command.
@@ -1052,7 +1052,7 @@ misty.SetHeadPosition(string axis, double position, double velocity, [int prePau
 ```
 
 Arguments
-* axis (string) - The axis to change. Values are `"yaw"` (turn), `"pitch"` (up-and-down), or `"roll"` (tilt). Passing a value of `"yaw"` or `"roll"` in a local skill running on Misty I robots does nothing.
+* axis (string) - The axis to change. Values are `"yaw"` (turn), `"pitch"` (up-and-down), or `"roll"` (tilt). Passing a value of `"yaw"` or `"roll"` in a skill running on Misty I robots does nothing.
 * position (double) - Indicates the position to move Misty’s head to along the given axis. Value range is -5 to 5. For pitch, -5 is fully up and 5 is fully down. For roll, -5 is fully left and 5 is fully right. For yaw, -5 is fully right and 5 is fully left.
 * velocity (double) - The speed of the head movement. Value range: 0 to 100.
 * prePause (integer) - Optional. The length of time in milliseconds to wait before executing this command.
@@ -1073,7 +1073,7 @@ misty.SetHeadRadians(string axis, double position, double velocity, [int prePaus
 ```
 
 Arguments
-* axis (string) - The axis to change. Values are `"yaw"` (turn), `"pitch"` (up-and-down), or `"roll"` (tilt). Passing a value of `"yaw"` or `"roll"` in a local skill running on Misty I robots does nothing.
+* axis (string) - The axis to change. Values are `"yaw"` (turn), `"pitch"` (up-and-down), or `"roll"` (tilt). Passing a value of `"yaw"` or `"roll"` in a skill running on Misty I robots does nothing.
 * position (double) - Indicates the radian to move Misty’s head to along the given axis. The value range for pitch is -0.1662 (fully up) to 0.6094 (fully down); for roll, -0.75 (fully left) to 0.75 (fully right); for yaw, -1.57 (fully right) to 1.57 (fully left). Note that due to normal variations in the range of head motion available to each robot, the minimum and maximum values for your Misty may differ slightly from the values listed here.
 * velocity (double) - The speed of the head movement. Value range: 0 to 100.
 * prePause (integer) - Optional. The length of time in milliseconds to wait before executing this command.
@@ -1192,7 +1192,7 @@ misty.FollowPath("100:250,125:275...");
 
 Obtains occupancy grid data for the most recent map Misty has generated. 
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 **Note:** To obtain a valid response from `misty.SlamGetRawMap()`, Misty must first have successfully generated a map. 
 
@@ -1221,7 +1221,7 @@ misty.SlamGetMap();
 
 Returns
 
-* Result (object) - An object containing the following key-value pairs. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+* Result (object) - An object containing the following key-value pairs. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
   * grid (array of arrays) - The occupancy grid for the most recent map Misty has generated, represented by a matrix of cells. The number of arrays is equal to the value of the `height` parameter. The number of cells is equal to the product of `height` x `width`. Each individual value (0, 1, 2, or 3) in the matrix represents a single cell of space. 0 indicates "unknown" space, 1 indicates "open" space, 2 indicates "occupied" space, and 3 indicates "covered" space. Each cell corresponds to an X,Y coordinate on the occupancy grid. The first cell in the first array is the X,Y origin point (0,0) for the map. The X coordinate of a given cell is the index of the array for the cell. The Y coordinate of a cell is the index of that cell within its array. If no map is available, grid returns `null`.
   * height (integer) - The height of the occupancy grid matrix (in number of cells).
   * isValid (boolean) - Returns a value of `true` if the data returned represents a valid map. If no valid map data is available, returns a value of `false`.
@@ -1235,7 +1235,7 @@ Returns
 
 Obtain a path from Misty’s current location to a specified set of X,Y coordinates. Pass the waypoints this command returns to the `path` parameter of `misty.FollowPath()` for Misty to follow this path to the desired location.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 **Important!** Make sure to call `misty.SlamStartTracking()` to start Misty tracking her location before using this command, and call `misty.SlamStopTracking()` to stop Misty tracking her location after using this command.
 
@@ -1260,12 +1260,12 @@ misty.SlamGetPath(100, 250);
 
 Returns
 
-* Result (array) - An array containing integer pairs. Each pair specifies the X,Y coordinates for a waypoint on the path. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+* Result (array) - An array containing integer pairs. Each pair specifies the X,Y coordinates for a waypoint on the path. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
 
 ### misty.SlamGetStatus - ALPHA
 Obtains values representing Misty's current activity and sensor status.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -1285,7 +1285,7 @@ misty.SlamGetStatus();
 ```
 
 Returns
-* Result (object) - A data object with the following key-value pairs. **Note:** In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+* Result (object) - A data object with the following key-value pairs. **Note:** In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
   * Status (integer) - An integer value where each bit is set to represent a different activity mode: 1 - Idle, 2 - Exploring, 3 - Tracking, 4 - Recording, 5 - Resetting. For example, if Misty is both exploring and recording, then bits 2 and 4 would be set => 0000 1010 => Status = 10.
   * SensorStatus (integer) - A number representing the status of Mistys' sensors, using the `SlamSensorStatus` enumerable.
   * RunMode (integer) - A number representing the status of Misty's navigation.
@@ -1640,7 +1640,7 @@ misty.UnregisterEvent("EventName");
 
 Obtains the robot's most recent log files. Note that log file data is stored for a maximum of 7 days.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -1661,7 +1661,7 @@ misty.GetLogFile();
 
 Returns
 
-* Result (list) - Compiled log file data. Returns an error message if no log data is found. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+* Result (list) - Compiled log file data. Returns an error message if no log data is found. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
 
 ### misty.SetLogLevel - ALPHA
 Sets the log level of the robot. The log level specifies where to write different types of messages sent by the system.
@@ -1689,7 +1689,7 @@ misty.SetLogLevel("Debug");
 ### misty.GetLogLevel - ALPHA
 Obtains the current log level of the robot.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
 
 ```JavaScript
 // Syntax
@@ -1710,7 +1710,7 @@ misty.GetLogLevel();
 
 Returns
 
-* level (string) - The current log level of the robot. In a local skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
+* level (string) - The current log level of the robot. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
 
 ### misty.Debug - ALPHA
 Prints a message to the JavaScript console for the Skill Runner web page in your browser.

--- a/src/content/docs/reference/javascript-api.md
+++ b/src/content/docs/reference/javascript-api.md
@@ -1687,6 +1687,7 @@ misty.SetLogLevel("Debug");
 ```
 
 ### misty.GetLogLevel - ALPHA
+
 Obtains the current log level of the robot.
 
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks).
@@ -1697,6 +1698,7 @@ misty.GetLogLevel([string callbackMethod], [string callbackRule = "synchronous"]
 ```
 
 Arguments
+
 * callbackMethod (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks). 
 * skillToCallUniqueId (string) - Optional. The unique id of a skill to trigger for the callback, instead of calling back into the same skill.
@@ -1713,6 +1715,7 @@ Returns
 * level (string) - The current log level of the robot. In an on-robot skill, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../docs/skills/local-skill-architecture/#-get-data-callbacks) for more information.
 
 ### misty.Debug - ALPHA
+
 Prints a message to the JavaScript console for the Skill Runner web page in your browser.
 
 When you use Skill Runner to run a skill, the `SkillData` WebSocket connection is established at the time you connect to your robot. This enables printing debug messages to the JavaScript console. You can use `misty.Debug()` to send your own messages to the console. **Note:** If `BroadcastMode` is set to `off` in the meta file for a skill, no debug messages are sent.
@@ -1723,6 +1726,7 @@ misty.Debug(string debugInfo, [int prePause], [int postPause]);
 ```
 
 Arguments
+
 * debugInfo (string) - The debug message to log to the console.
 * prePause (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPause (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPause` is not used.
@@ -1733,6 +1737,7 @@ misty.Debug("Message")
 ```
 
 ### misty.Publish - ALPHA
+
 Writes data to the robot's internal log.
 
 Note that `misty.Publish()` writes data to the robot's internal log file, even when called in a skill with the value of `WriteToLog` set to `False` in its meta file. You can use the API Explorer to download your robot's log files, or send a GET request to the REST endpoint for the [`GetLogFile`](../../../docs/reference/rest/#getlogfile) command. 
@@ -1743,6 +1748,7 @@ misty.Publish(string name, string value)
 ```
 
 Arguments
+
 * name (string) - A name for the data to write to the robot's log.
 * value (string, integer, double, or boolean) - The data to write to the robot's log. To write an object, you must serialize your data into a string using `JSON.stringify()`.
 
@@ -1754,6 +1760,7 @@ misty.Publish("data-name", "data-value");
 ## Persistent Data
 
 ### misty.Get - ALPHA
+
 Returns data saved to the robot using `misty.Set()`. 
 
 ```JavaScript
@@ -1762,6 +1769,7 @@ misty.Get(string key, [int prePause], [int postPause]);
 ```
 
 Arguments
+
 * key (string) - The key name of the data to return.
 * prePause (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPause (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPause` is not used.
@@ -1772,9 +1780,11 @@ misty.Get("Key");
 ```
 
 Returns
+
 * value (string, boolean, integer, or double) - The data associated with the specified key.
 
 ### misty.Keys - ALPHA
+
 Returns a list of all the available persistent data stored on the robot. 
 
 ```JavaScript
@@ -1783,6 +1793,7 @@ misty.Keys([int prePause], [int postPause]);
 ```
 
 Arguments
+
 * prePause (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPause (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPause` is not used.
 
@@ -1792,9 +1803,11 @@ misty.Keys();
 ```
 
 Returns
+
 * keys (list) - A list of the keys and values for all available persistent data stored on the robot.
 
 ### misty.Remove - ALPHA
+
 Removes data that has been saved to the robot under a specific key with `misty.Set()`. 
 
 ```JavaScript
@@ -1803,6 +1816,7 @@ misty.Remove(string key, [int prePause], [int postPause])
 ```
 
 Arguments
+
 * key (string) - The key name of the data to remove.
 * prePause (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPause (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPause` is not used.
@@ -1813,6 +1827,7 @@ misty.Remove("Key");
 ```
 
 ### misty.Set - ALPHA
+
 Saves data that can be validly updated and used across threads or shared between skills. 
 
 **Important!** Data stored via the `misty.Set()` command **does not persist across a reboot** of the robot at this time.
@@ -1825,6 +1840,7 @@ misty.Set(string key, string value, [int prePause], [int postPause]);
 ```
 
 Arguments
+
 * key (string) - The key name for the data to save.
 * value (value) - The data to save. Data saved using `misty.Set()` must be one of these types: `string`, `bool`, `int`, or `double`.
 * prePause (integer) - Optional. The length of time in milliseconds to wait before executing this command.
@@ -1838,6 +1854,7 @@ misty.Set("Key", "Value");
 ## External Server Communication
 
 ### misty.SendExternalRequest - ALPHA
+
 Sends an HTTP request from Misty to an external server. You use `misty.SendExternalRequest()` to access resources that are available via Uniform Resource Identifiers (URIs), such as cloud-based APIs or data stored on a server in another location.
 
 **Note:** In most cases, the external server's response to requests sent from the robot must be passed into a callback function to be processed and made available for use in your skills. By default, the callback function for this command is given the same name as the command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by `misty.SendExternalRequest()`, see the [External Requests](../../../docs/skills/local-skill-tutorials/#external-requests) tutorial.

--- a/src/content/docs/reference/sensor-data.md
+++ b/src/content/docs/reference/sensor-data.md
@@ -7,7 +7,7 @@ order: 3
 
 # {{title}}
 
-The following are Misty’s available sensor and skill data types. You receive this data when you register for events in an on-robot skill or when you subscribe to a WebSocket connection from a remote device.
+The following are Misty’s available sensor and skill data types. You receive this data when you register for events in an on-robot skill or when you subscribe to a WebSocket connection from an external device.
 
 You can filter all data types to (a) return only a specified subset of the data and (b) check current values before the data is sent.
 

--- a/src/content/docs/reference/sensor-data.md
+++ b/src/content/docs/reference/sensor-data.md
@@ -7,7 +7,7 @@ order: 3
 
 # {{title}}
 
-The following are Misty’s available sensor and skill data types. You receive this data when you register for events in a local skill or when you subscribe to a WebSocket connection from a remote device.
+The following are Misty’s available sensor and skill data types. You receive this data when you register for events in an on-robot skill or when you subscribe to a WebSocket connection from a remote device.
 
 You can filter all data types to (a) return only a specified subset of the data and (b) check current values before the data is sent.
 
@@ -373,7 +373,7 @@ The `ActuatorPosition` data stream provides information about the position of th
 
 In the `ActuatorPosition` data object, the value of the `sensorName` property is the name of the actuator you are receiving information about (`Actuator_HeadPitch`, `Actuator_HeadYaw`, `Actuator_HeadRoll`, `Actuator_LeftArm`, or `Actuator_RightArm`).  The `value` property holds a number indicating the position of the actuator (in radians).
 
-**Note:** When you subscribe to the `ActuatorPosition` data stream, you should specify which actuator you want to receive messages about. For example, the following code from a local skill shows how to use a property comparison test to get data from the sensor for the actuator responsible for controlling the movement of Misty's right arm:
+**Note:** When you subscribe to the `ActuatorPosition` data stream, you should specify which actuator you want to receive messages about. For example, the following code from an on-robot skill shows how to use a property comparison test to get data from the sensor for the actuator responsible for controlling the movement of Misty's right arm:
 
 ```JavaScript
 // Register for ActuatorPosition data for the actuator for Misty's right arm
@@ -406,9 +406,9 @@ ActuatorPosition {
 ## BumpSensor
 **Available for Misty II only**
 
-The `BumpSensor` data stream sends information each time one of the bump sensors on Misty's base is pressed or released. In the `BumpSensor` data object, the value of the `sensorName` property is the name of the bump sensor that triggered the event (`Bump_FrontRight`, `Bump_FrontLeft`, `Bump_RearRight`, or `Bump_RearLeft`). The value of the `isContacted` property is a boolean indicating whether the bump sensor was pressed (`true`) or released (`false`).The `BumpSensor` data object also provides “pose” information about Misty at the time of the event. For more about pose, see the [mapping section of the API Explorer documentation](../../../docs/apps/api-explorer/#mapping-amp-tracking-alpha). 
+The `BumpSensor` data stream sends information each time one of the bump sensors on Misty's base is pressed or released. In the `BumpSensor` data object, the value of the `sensorName` property is the name of the bump sensor that triggered the event (`Bump_FrontRight`, `Bump_FrontLeft`, `Bump_RearRight`, or `Bump_RearLeft`). The value of the `isContacted` property is a boolean indicating whether the bump sensor was pressed (`true`) or released (`false`).The `BumpSensor` data object also provides “pose” information about Misty at the time of the event. For more about pose, see the [mapping section of the API Explorer documentation](../../../docs/apps/api-explorer/#mapping-amp-tracking-alpha).
 
-For an example that shows how to register for and use data from `BumpSensor` events in a local skill, see the [Bump Sensors skill tutorial](../../../docs/skills/local-skill-tutorials/#bump-sensors-misty-ii-).
+For an example that shows how to register for and use data from `BumpSensor` events in an on-robot skill, see the [Bump Sensors skill tutorial](../../../docs/skills/local-skill-tutorials/#bump-sensors-misty-ii-).
 
 Sample `BumpSensor` data:
 
@@ -585,7 +585,7 @@ Sending data to Misty as a JSON string can make it easier to parse the data in y
 Serial.println("{\"temperature\":\""+String(<temp_value>)+"\",\"pressure\":\""+String(<pressure_value>)+"\"}");
 ```
 
-Handle this data in a local skill by registering for `StringMessage` events. Add `StringMessage` as an additional return property, and parse the data in the `_StringMessage()` callback that triggers when the data is ready.
+Handle this data in an on-robot skill by registering for `StringMessage` events. Add `StringMessage` as an additional return property, and parse the data in the `_StringMessage()` callback that triggers when the data is ready.
 
 ```JavaScript
 // MISTY 
@@ -604,7 +604,7 @@ function _StringMessage(data) {
 }
 ```
 
-For more about events and callbacks, see the [Data Handling: Events & Callbacks](../../../docs/skills/local-skill-architecture/#data-handling-events-amp-callbacks) section of [Local Skill Architecture](../../../docs/skills/local-skill-architecture).
+For more about events and callbacks, see the [Data Handling: Events & Callbacks](../../../docs/skills/local-skill-architecture/#data-handling-events-amp-callbacks) section of [On-Robot JavaScript API Architecture](../../../docs/skills/local-skill-architecture).
 
 ## TouchSensor
 **Available for Misty II only**

--- a/src/content/docs/skills/introduction.md
+++ b/src/content/docs/skills/introduction.md
@@ -7,6 +7,6 @@ order: 1
 
 # {{title}}
 
-Misty has two basic types of skill architecture: local and remote. 
+Misty has two basic types of skill architecture. You can write skills using Misty's on-robot JavaScript API, or you can use her REST API.
 
-When you write a [local skill](../../skills/local-skill-architecture), you upload your code to the robot, and it runs internally on Misty. This differs from [using remote commands](../../skills/remote-command-architecture) with Misty, where your code runs on an external device (say, in desktop browser or on a Raspberry Pi) and not onboard the robot.
+When you write a skill using Misty's [on-robot JavaScript API](../../skills/local-skill-architecture), you upload your code to the robot and it runs internally on Misty. This differs from writing a skill with [Misty's REST API](../../skills/remote-command-architecture), where your code runs on an external device (say, in desktop browser or on a Raspberry Pi) and not onboard the robot.

--- a/src/content/docs/skills/local-skill-architecture.md
+++ b/src/content/docs/skills/local-skill-architecture.md
@@ -1,5 +1,5 @@
 ---
-title: Local Skill Architecture
+title: On-Robot JavaScript API Architecture
 layout: coding.hbs
 columns: three
 order: 2
@@ -7,9 +7,9 @@ order: 2
 
 # {{title}}
 
-When you write a local skill, your code takes advantage of Misty’s capabilities as a standalone “edge” computing device. Local skills can also interact with external data and use non-Misty API calls to cloud services, etc.
+When you write a skill using Misty's on-robot JavaScript APi, your code takes advantage of Misty’s capabilities as a standalone “edge” computing device. On-robot skills can also interact with external data and use non-Misty API calls to cloud services, etc.
 
-**IMPORTANT! Local skills are a pre-release, “alpha” technology and are subject to frequent change.** Any local skills you create for Misty may need updates before release to reflect ongoing development of the local skill architecture and implementation. Local skills will be publicly available at the time when Misty II ships.
+**IMPORTANT! On-robot skills are a pre-release, “alpha” technology and are subject to frequent change.** Any on-robot skills you create for Misty may need updates before release to reflect ongoing development of Misty's skill architecture and implementation. Local skills will be publicly available at the time when Misty II ships.
 
 You can read this architecture section to understand the details of how to write local skills. However, you can also simply start right in with the [local skill tutorials](../../skills/local-skill-tutorials) and just skim the following list to get an idea of what you might want to read about later:
 

--- a/src/content/docs/skills/local-skill-architecture.md
+++ b/src/content/docs/skills/local-skill-architecture.md
@@ -290,7 +290,7 @@ The system supplies the following types of helper commands to assist you in writ
 
 ### Skill Management Commands
 
-The system provides REST commands that you can use to control and manage on-robot skills from a remote device. For information about these commands, see [Skill Management Commands](../../../docs/reference/rest/#skill-management-commands). These commands allow you to:
+The system provides REST commands that you can use to control and manage on-robot skills from an external device. For information about these commands, see [Skill Management Commands](../../../docs/reference/rest/#skill-management-commands). These commands allow you to:
 
 * Upload skills to the robot
 * Load, reload, or unload one or more skills

--- a/src/content/docs/skills/local-skill-architecture.md
+++ b/src/content/docs/skills/local-skill-architecture.md
@@ -7,7 +7,7 @@ order: 2
 
 # {{title}}
 
-When you write a skill using Misty's on-robot JavaScript APi, your code takes advantage of Misty’s capabilities as a standalone “edge” computing device. On-robot skills can also interact with external data and use non-Misty API calls to cloud services, etc.
+When you write a skill using Misty's on-robot JavaScript API, your code takes advantage of Misty’s capabilities as a standalone “edge” computing device. On-robot skills can also interact with external data and use non-Misty API calls to cloud services, etc.
 
 **IMPORTANT! On-robot skills are a pre-release, “alpha” technology and are subject to frequent change.** Any on-robot skills you create for Misty may need updates before release to reflect ongoing development of Misty's skill architecture and implementation. Local skills will be publicly available at the time when Misty II ships.
 

--- a/src/content/docs/skills/local-skill-architecture.md
+++ b/src/content/docs/skills/local-skill-architecture.md
@@ -9,29 +9,29 @@ order: 2
 
 When you write a skill using Misty's on-robot JavaScript API, your code takes advantage of Misty’s capabilities as a standalone “edge” computing device. On-robot skills can also interact with external data and use non-Misty API calls to cloud services, etc.
 
-**IMPORTANT! On-robot skills are a pre-release, “alpha” technology and are subject to frequent change.** Any on-robot skills you create for Misty may need updates before release to reflect ongoing development of Misty's skill architecture and implementation. Local skills will be publicly available at the time when Misty II ships.
+**IMPORTANT! On-robot skills are a pre-release, “alpha” technology and are subject to frequent change.** Any on-robot skills you create for Misty may need updates before release to reflect ongoing development of Misty's skill architecture and implementation. On-robot skills will be publicly available at the time when Misty II ships.
 
-You can read this architecture section to understand the details of how to write local skills. However, you can also simply start right in with the [local skill tutorials](../../skills/local-skill-tutorials) and just skim the following list to get an idea of what you might want to read about later:
+You can read this architecture section to understand the details of how to write on-robot skills. However, you can also simply start right in with the [on-robot skill tutorials](../../skills/local-skill-tutorials) and just skim the following list to get an idea of what you might want to read about later:
 
-* Command Syntax. The local skill command syntax differs slightly from that of remote skill commands. 
-* Data Handling: Events and Callbacks. Both stored and live data from the robot are made available to a local skill via callback functions.
+* Command Syntax. The on-robot JavaScript API command syntax differs slightly from that of REST API commands.
+* Data Handling: Events and Callbacks. Both stored and live data from the robot are made available to an on-robot skill via callback functions.
   * “Get” Data Callbacks
   * Sensor Event Callbacks
   * Timed or Triggered Event Callbacks
-* Data Handling: Variables. There are two ways to store persistent data with local skills: as a global variable or as “set” data.
-* Command Type Reference. There are several command types available to local skills, with some usage differences among them.
+* Data Handling: Variables. There are two ways to store persistent data with on-robot skills: as a global variable or as “set” data.
+* Command Type Reference. There are several command types available to on-robot skills, with some usage differences among them.
   * Action Commands
   * Get Commands
   * Event Commands
   * Helper Commands
   * Skill Management Commands
-* File Structure & Code Architecture. There are two required file types for a local skill: a “meta” JSON file and a “code” JavaScript file.
-* Loading & Running a Local Skill. There are currently two options for how you load and run skills.
-* Starting & Stopping a Local Skill. Currently, local skills running on Misty I must be triggered to start/stop from an external request.
+* File Structure & Code Architecture. There are two required file types for a an on-robot skill: a “meta” JSON file and a “code” JavaScript file.
+* Loading & Running an On-Robot Skill. There are currently two options for how you load and run skills.
+* Starting & Stopping an On-Robot Skill. Currently, you must use Misty's REST API to start or stop an on-robot skill.
 
 ## Command Syntax
 
-In a local skill, the syntax for using a command is:
+In Misty's on-robot JavaScript API, the syntax for using a command is:
 
 ```JavaScript
 misty.<COMMAND>(parameters);
@@ -43,7 +43,7 @@ So, for example, to change the color of Misty’s logo LED, you would call the `
 misty.ChangeLED(255, 0, 0);
 ```
 
-When used with local skills, most of Misty’s commands also allow you to pass in optional “pre-pause” and “post-pause” values, to add delays before the command is run or after. When we show a command, optional parameters are inside brackets. So the `Drive()` command is represented as:
+Most commands in the JavaScript API also allow you to pass in optional “pre-pause” and “post-pause” values, to add delays before the command is run or after. When we show a command, optional parameters are inside brackets. So the `Drive()` command is represented as:
 
 ```JS
 misty.Drive(double linearVelocity, double angularVelocity, [int prePause], [int postPause]);
@@ -71,7 +71,7 @@ You typically get two kinds of information from your robot:
 * Stored data, such as the list of audio files currently saved on the robot. This is the type of data you could obtain with one of Misty’s “Get” commands, for example.
 * Live sensor “event” data, such as distance information, face detection events, etc.
 
-Both types of data are made available to local skills via callbacks, so you must implement callback methods to be informed when data is ready.
+Both types of data are made available to the code running on your robot via callbacks, so you must implement callback methods to be informed when data is ready.
 
 The syntax and usage of callback commands for these two types of data varies. Additionally, there is a third category of callbacks you can create for Misty: timed or triggered callbacks. Their usage and syntax are described at the end of this section.
 
@@ -79,7 +79,7 @@ The syntax and usage of callback commands for these two types of data varies. Ad
 
 For “get” callback functions, the callback name is by default set to be  `_<COMMAND>` (you can use your own callback name if desired). So, for example, the default callback function for `GetDeviceInformation` would be `_GetDeviceInformation`.
 
-A “get” callback function must have exactly one parameter. That parameter holds the data returned through the callback. Note that a local skill callback returns data as an object, not as a JSON string value. An example use of a callback to obtain an audio list and play a random sound is as follows:
+A “get” callback function must have exactly one parameter. That parameter holds the data returned through the callback. Note that when you use Misty's on-robot JavaScript API the callback returns data as an object, not as a JSON string value. An example use of a callback to obtain an audio list and play a random sound is as follows:
 
 ```JS
 StartMySkill();
@@ -217,7 +217,9 @@ With a JSON body similar to:
 The `UniqueId` and `EventName` values are required and must match the ID of the skill to call and the event name you used in that skill. You should place any payload data you wish to send to the skill in the `Payload` field.
 
 ## Data Handling: Variables
-There are two ways to store persistent data with local skills:
+
+There are two ways to store persistent data with on-robot skills:
+
 * In a global variable, where the data is available (but not updated) across threads in a single skill
 * As “set” data, where the data is available (and updated) across threads in a single skill and is shareable among skills
 
@@ -279,41 +281,43 @@ All of the event command types require you to implement a callback to be notifie
 <!-- TODO: Add link to Timed or Triggered Event Callbacks section -->
 
 ### Helper Commands
-The system supplies the following types of helper commands to assist you in creating a local skill for Misty.
 
-* **Persistent Data.** To create data that persists across skills, you must use one of the following helper commands to save (set) that data to the robot or to get that data from the robot: `Set`, `Get`, `Remove`, `Keys`. Persistent data must be saved as one of these types: `string`, `bool`, `int`, or `double`. Alternately, you can serialize your data into a string using `JSON.stringify()` and parse it out again using `JSON.parse()`. Currently, any data saved to the robot this way is not automatically deleted and by default may be used across multiple skills. **Important!** Data stored via the `Set()` command does not persist across a reboot of the robot at this time.
-* **External Data.** Another type of helper command allows your local skill to use data from the Internet. The `SendExternalRequest()` command allows you to obtain remote data and optionally save it to the robot and/or use it immediately. See the [External Requests](../../skills/local-skill-tutorials/#external-requests) tutorial for an example of using this functionality. <!--TODO: Add link to sendexternalrequest tutorial-->
-* **Pausing and Debugging.** There are a few additional helper commands you can use to help with your local skill: `Pause`, `RandomPause`, `Debug`, `CancelSkill`, and `Publish`. These commands are described in the [JavaScript API reference documentation](../../reference/javascript-api). Note: A local skill must have `BroadcastMode` set to `Verbose`, `Debug`, or `All` in the meta file for debug statements to be broadcast. By default, debug statements are set to `Off`.
+The system supplies the following types of helper commands to assist you in writing skills with Misty's on-robot JavaScript API.
+
+* **Persistent Data.** To create data that persists across skills, you must use one of the following helper commands to save (set) that data to the robot or to get that data from the robot: `misty.Set()`, `misty.Get()`, `misty.Remove()`, `misty.Keys()`. Persistent data must be saved as one of these types: `string`, `bool`, `int`, or `double`. Alternately, you can serialize your data into a string using `JSON.stringify()` and parse it out again using `JSON.parse()`. Currently, any data saved to the robot this way is not automatically deleted and by default may be used across multiple skills. **Important!** Data stored via the `Set()` command does not persist across a reboot of the robot at this time.
+* **External Data.** Another type of helper command allows your skill to use data from the Internet. The `SendExternalRequest()` command allows you to obtain remote data and optionally save it to the robot and/or use it immediately. See the [External Requests](../../skills/local-skill-tutorials/#external-requests) tutorial for an example of using this functionality. <!--TODO: Add link to sendexternalrequest tutorial-->
+* **Pausing and Debugging.** There are a few additional helper commands you can use to help with your skill: `misty.Pause()`, `misty.RandomPause()`, `misty.Debug()`, `misty.CancelSkill()`, and `misty.Publish()`. These commands are described in the [On-Robot JavaScript API reference documentation](../../reference/javascript-api). Note: An on-robot skill must have `BroadcastMode` set to `Verbose`, `Debug`, or `All` in the meta file for debug statements to be broadcast. By default, debug statements are set to `Off`.
 
 ### Skill Management Commands
-The system provides some REST commands that you can use to control local skills from a remote device. For information about these commands, see the section on [REST API](../../reference/rest) commands for managing skills. These commands allow you to:
+
+The system provides REST commands that you can use to control and manage on-robot skills from a remote device. For information about these commands, see [Skill Management Commands](../../../docs/reference/rest/#skill-management-commands). These commands allow you to:
+
 * Upload skills to the robot
 * Load, reload, or unload one or more skills
 * Run a skill
 * Get a list of uploaded skills on the robot
 * Cancel a running skill
 * Trigger an event within a skill
- 
+
 ## File Structure & Code Architecture
-There are two basic file types required for a local skill: a “meta” JSON file and a “code” JavaScript file. On the robot, these files are located in the following directory structure:
 
-<!-- TODO: cleanup the code samples below -->
+There are two basic file types required for an on-robot skill: a “meta” JSON file and a “code” JavaScript file. On the robot, these files are located in the following directory structure:
 
-```
-User Folders\Music\SDKAssets\Misty\Skills\Meta\[filename.json]
-User Folders\Music\SDKAssets\Misty\Skills\Code\[filename.js]
+```JavaScript
+User Folders\Music\SDKAssets\Misty\Skills\Meta\<filename>.json
+User Folders\Music\SDKAssets\Misty\Skills\Code\<filename>.js
 ```
 
 Each skill MUST have files of the same name in both the `Code` and `Meta` folders. For example:
 
-```
+```JavaScript
 User Folders\Music\SDKAssets\Misty\Skills\Meta\Roam.json
 User Folders\Music\SDKAssets\Misty\Skills\Code\Roam.js
 ```
 
 ### Meta File
 
-Every local skill must include a named meta file with a `.json` extension. This brief meta file enables Misty to understand what your skill does and how to execute your code. For example:
+Every on-robot skill must include a named meta file with a `.json` extension. This brief meta file enables Misty to understand what your skill does and how to execute your code. For example:
 
 ```json
 {
@@ -348,14 +352,14 @@ _global = _params.foo;
 ```
 
 ### Code File
-The `.js` code file contains the running code for your local skill. A valid JavaScript code file can be even simpler than a corresponding JSON `meta` file. Here’s an example of a complete, very simple code file for a local skill:
+The `.js` code file contains the running code for your on-robot skill. A valid JavaScript code file can be even simpler than a corresponding JSON `meta` file. Here’s an example of a complete, very simple code file for an on-robot skill:
 
 ```js
 misty.Debug("Hello, World!");
 misty.ChangeLED(0, 255, 0);
 ```
 
-Most local skills include callback functions and registering and unregistering of events. That’s because most local skills interact with data in some way. For example, when sensor data is sent from Misty to your code, it triggers an event, and this in turn executes the callback function for the registered event.
+Most skills that use the on-robot JavaScript API include callback functions and registering and unregistering of events. That’s because most of these skills interact with data in some way. For example, when sensor data is sent from Misty to your code, it triggers an event, and this in turn executes the callback function for the registered event.
 
 In the sample skill code file below, an event callback function is used to handle sensor data from one of Misty’s time-of-flight sensors:
 
@@ -391,8 +395,10 @@ Note that when a skill starts, the code within the skill automatically starts ru
 
 If `CleanupOnCancel` is set to `true` in the meta file, then when a skill is cancelled, additional commands are automatically issued to stop running processes that may have been started in the skill. These process might include facial detection / recognition / training, SLAM mapping / tracking / recording / streaming, and record audio. If `CleanupOnCancel` is set to `false`, then this additional cleanup does not occur when cancelled (`false` is currently the default value). Currently, this does not affect the behavior of the skill if it ends normally. These commands are not automatically issued in this case.
 
-## Loading & Running a Local Skill
+## Loading & Running an On-Robot Skill
+
 Once you’ve created the files for your skill, you must load them onto your robot before you can run them. The two methods for loading skills onto Misty are:
+
 * the [Misty Skill Runner](../../skills/tools/#misty-skill-runner) web tool, which provides a simple upload feature
 * a REST tool such as Postman that can send a `POST` request to the dedicated endpoint for skill deployment
 
@@ -419,8 +425,9 @@ There are many ways to send a `POST` request to the skill deployment endpoint, b
 12. Click **Reload Skills** at the top of the page. This ensures that your robot and latest code changes are in sync. Observe the JavaScript console for a log message verifying the skills have been loaded.
 13. To run your skill, enter the skill’s name under “Run Skill” and click **Run**. Continue observing the console; as events are triggered, you’ll see debug messages in the console.
 
-## Starting & Stopping a Local Skill
-Currently, local skills running on Misty I must be triggered to start/stop from an external command. This command can be sent via a REST client or as a JavaScript AJAX request.
+## Starting & Stopping an On-Robot Skill
+
+Currently, you must use Misty's REST API to trigger an on-robot skill to start or stop. You can use the Skill Runner interface or a REST client like Postman to send these commands, or you can write your own code to send the command from an external device.
 
 To start a skill, send the `RunSkill POST` command with the following syntax. Note that the `Skill` value must be the same as the `Name` value for the skill in its JSON `meta` file.
 
@@ -468,4 +475,4 @@ POST http://<robot-ip-address>/api/alpha/sdk/cancel
 {}
 ```
 
-**Important!** Local skills are subject to a default timeout of 5 minutes. After 5 minutes the skill will cancel, even if it is performing actions or waiting on callbacks. This duration can be changed by providing a different `TimeoutInSeconds` value in the `meta` file. In addition, if a skill is not performing any actions nor waiting on any commands, it will automatically cancel after 5 seconds.
+**Important!** Skills running on the robot are subject to a default timeout of 5 minutes. After 5 minutes the skill will cancel, even if it is performing actions or waiting on callbacks. This duration can be changed by providing a different `TimeoutInSeconds` value in the `meta` file. In addition, if a skill is not performing any actions nor waiting on any commands, it will automatically cancel after 5 seconds.

--- a/src/content/docs/skills/local-skill-tutorials.md
+++ b/src/content/docs/skills/local-skill-tutorials.md
@@ -1,5 +1,5 @@
 ---
-title: On-Robot Skill Tutorials
+title: On-Robot JavaScript API Tutorials
 layout: coding.hbs
 columns: three
 order: 4

--- a/src/content/docs/skills/local-skill-tutorials.md
+++ b/src/content/docs/skills/local-skill-tutorials.md
@@ -1,5 +1,5 @@
 ---
-title: Local Skill Tutorials
+title: On-Robot Skill Tutorials
 layout: coding.hbs
 columns: three
 order: 4
@@ -7,13 +7,20 @@ order: 4
 
 # {{title}}
 
-In these tutorials you will learn everything you need to know to begin writing local skills for your Misty robot. Each tutorial introduces a new aspect of skill development to expose the full breadth of Misty's capabilities and potential.
+In these tutorials you will learn everything you need to know to begin writing skills using Misty's on-robot JavaScript API. Each tutorial introduces a new aspect of skill development to expose the full breadth of Misty's capabilities and potential.
 
 ## Time-of-Flight
 
 In this tutorial we create a simple skill that changes Misty’s chest LED, drives her forward for 10 seconds, and tells her to stop if she detects an object in her path. We go over how to send commands, subscribe to sensor events, and structure your skill data. Let’s get started!
 
-The code for local skills is comprised of two parts. The logic used to define how the skill functions is located in a `.js` file located in the `/Code` directory under `/Skills`. In addition to this, there is a corresponding `.json` file in the `/Meta` directory. These files must have the same name. Create a `.js` file and call it `HelloWorld_TimeOfFlight.js`. Then create a `.json` file and give it the same name. When the skill is complete, we use [Skill Runner](../../skills/tools/#misty-skill-runner) to upload these files to the directories specified above.
+When you write a skill using Misty's on-robot JavaScript API, the following elements are required:
+
+* a `.js` "code" file with the logic used to define how the skill functions
+* a `.json` "meta" file with rules that describe how Misty should execute the code in the corresponding "code" file.
+
+The JavaScript "code" and JSON "meta" files for a skill **must** be given the same name.
+
+To begin, create a `.js` file and call it `HelloWorld_TimeOfFlight.js`. Then create a `.json` file and give it the same name. When the skill is complete, we use [Skill Runner](../../skills/tools/#misty-skill-runner) to upload these files to the directories specified above.
 
 ### Writing the Meta File
 
@@ -105,7 +112,7 @@ misty.ChangeLED(255, 0, 0);
 misty.Debug("ending skill helloworld ");
 ```
 
-Congratulations! You have just written a local skill for Misty. Save the code file with the name `HelloWorld_TimeOfFlight.js`. See the documentation on using [Misty Skill Runner](../../skills/tools/#misty-skill-runner) or the REST API to [load your skill data onto Misty and run the skill from the browser](../../skills/local-skill-architecture/#loading-amp-running-a-local-skill). 
+Save the code file with the name `HelloWorld_TimeOfFlight.js`. See the documentation on using [Misty Skill Runner](../../skills/tools/#misty-skill-runner) or the REST API to [load your skill data onto Misty and run the skill from the browser](../../skills/local-skill-architecture/#loading-amp-running-a-local-skill). 
 
 See the full contents of the `HelloWorld_TimeOfFlight.js` file here for reference.
 
@@ -506,7 +513,7 @@ else {
 }
 ```
 
-Using timed events, we have told Misty to change her chest LED to a random color in three-second intervals. We have demonstrated how we can use global variables prefixed with an underscore to have data persist across threads that are created in our program as callbacks are triggered. This is a simple example of two powerful tools that you have at your disposal when writing local skills for Misty. 
+Using timed events, we have told Misty to change her chest LED to a random color in three-second intervals. We have demonstrated how we can use global variables prefixed with an underscore to have data persist across threads created in our program as callbacks are triggered.
 
 Save the code file with the name `HelloWorld_TimerEvent.js`. See the documentation on using [Misty Skill Runner](../../skills/tools/#misty-skill-runner) or the REST API to [load your skill data onto Misty and run the skill from the browser](../../skills/local-skill-architecture/#loading-amp-running-a-local-skill).
 
@@ -592,7 +599,7 @@ The sixth required parameter (`jsonArgs`) holds the data to send with `POST` req
 
 The optional `saveAssetToRobot`, `applyAssetAfterSaving`, and `fileName` parameters tell Misty how to handle images and audio files returned by requests. Pass `true` for `saveAssetToRobot` to have Misty save the file to local storage. Pass `true` to `applyAssetAfterSaving` to play the audio file immediately after it is saved (or, if the returned file is an image, to display it on Misty's screen). The string you pass for `fileName` specifies a name for the saved file (this example uses `sound`).
 
-The optional `callbackMethod`, `callbackRule`, and `skillToCallOnCallback` parameters designate a function or skill to receive the data returned by the request and indicate the callback rule Misty should follow to execute the callback. Read more about callbacks and callback rules in [Data Handling: Events & Callbacks](../../skills/local-skill-architecture/#data-handling-events-amp-callbacks). This example does not use a callback function, so you can omit these parameters, or pass `null` if you want to use the `prePause` and `postPause` parameters that follow them. As with other local skill commands, `prePause` and `postPause` are optional in `misty.SendExternalRequest()`.
+The optional `callbackMethod`, `callbackRule`, and `skillToCallOnCallback` parameters designate a function or skill to receive the data returned by the request and indicate the callback rule Misty should follow to execute the callback. Read more about callbacks and callback rules in [Data Handling: Events & Callbacks](../../skills/local-skill-architecture/#data-handling-events-amp-callbacks). This example does not use a callback function, so you can omit these parameters, or pass `null` if you want to use the `prePause` and `postPause` parameters that follow them. Note that `prePause` and `postPause` are optional in `misty.SendExternalRequest()`.
 
 The final form of `misty.SendExternalRequst()` in this tutorial is:
 
@@ -1158,7 +1165,7 @@ function _GetListOfAudioClips(data) {
 }
 ```
 
-When the list of audio clips is available, we can assign the names of different audio files to four unique global variables. We access the names of audio files by digging into the response data from `misty.GetListOfAudioClips()`, which contains an array of audio file data. In local skills, global variables are prefixed with an underscore (i.e. `_globalVar`) and do not require identifiers such as `var`, `let`, or `const`.
+When the list of audio clips is available, we can assign the names of different audio files to four unique global variables. We access the names of audio files by digging into the response data from `misty.GetListOfAudioClips()`, which contains an array of audio file data. In Misty's on-robot JavaScript API, global variables are prefixed with an underscore (i.e. `_globalVar`) and do not require identifiers such as `var`, `let`, or `const`.
 
 In the `_GetListOfAudioClips()` callback, assign the first four results in the audio data array to four unique global variables. These variables can be accessed from within the callback we write to handle bump sensor events, where we'll map them to each of Misty's bump sensors.
 
@@ -1266,9 +1273,9 @@ function _BumpSensor(data) {
 }
 ```
 
-When this skill runs, Misty retrieves the list of audio clips in her local storage and associates the names of four audio files with unique global variables. She then registers for bump sensor events. Each time an event occurs, Misty determines which bump sensor was pressed and plays the sound associated with that sensor. 
+When this skill runs, Misty retrieves the list of audio clips in her local storage and associates the names of four audio files with unique global variables. She then registers for bump sensor events. Each time an event occurs, Misty determines which bump sensor was pressed and plays the sound associated with that sensor.
 
-**Note:** By default local skills timeout after 300 seconds, so this skill automatically stops executing after 5 minutes. This duration can be changed by changing the value of the `TimeoutInSeconds` property in the meta file. 
+**Note:** By default on-robot skills timeout after 300 seconds, so this skill automatically stops executing after 5 minutes. This duration can be changed by changing the value of the `TimeoutInSeconds` property in the meta file. 
 
 Save the code file with the name `HelloWorld_BumpSensors.js`. See the documentation on using [Misty Skill Runner](../../skills/tools/#misty-skill-runner) or the REST API to [load your skill data onto Misty and run the skill from the browser](../../skills/local-skill-architecture/#loading-amp-running-a-local-skill). 
 

--- a/src/content/docs/skills/remote-command-architecture.md
+++ b/src/content/docs/skills/remote-command-architecture.md
@@ -1,5 +1,5 @@
 ---
-title: Remote Command Architecture
+title: Rest API & WebSocket Architecture
 layout: coding.hbs
 columns: three
 order: 3
@@ -7,13 +7,16 @@ order: 3
 
 # {{title}}
 
-Misty’s remote command interface is based on a powerful REST API. The examples in this topic are written in JavaScript and use helper libraries to simplify making requests and subscribing to Misty’s WebSocket connections. You can also use the community owned [Python wrapper](https://github.com/MistyCommunity/Wrapper-Python) or a REST client such as Postman to send Misty commands.
+In addition to her on-robot JavaScript API, you can also write skills for Misty using her powerful REST API.
 
-Creating your own remote skill for Misty typically involves two things: getting data from Misty via WebSocket connections and sending commands to Misty using her API. This topic walks you through both sides of this process.
+Writing a skill this way typically involves two things: getting data from Misty via WebSocket connections and sending commands to Misty using her REST API. This topic walks you through both sides of this process.
+
+The examples in this topic are written in JavaScript and use helper libraries to simplify making requests and subscribing to Misty’s WebSocket connections. You can also use the community owned [Python wrapper](https://github.com/MistyCommunity/Wrapper-Python) or a REST client such as Postman to send Misty commands.
 
 ## Sending Commands to Misty
 
 Misty's API includes commands for:
+
 * Display and light control
 * Audio control
 * Face detection, training, and recognition

--- a/src/content/docs/skills/remote-command-tutorials.md
+++ b/src/content/docs/skills/remote-command-tutorials.md
@@ -1,5 +1,5 @@
 ---
-title: Remote Command Tutorials
+title: REST API & WebSocket Tutorials
 layout: coding.hbs
 columns: three
 order: 5
@@ -23,7 +23,7 @@ This tutorial uses Misty’s REST API to send a POST request that changes the co
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>Remote Command Tutorial 1</title>
+    <title>Tutorial | Changing Misty's LED</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- Reference a link to a CDN for Axios here -->
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
@@ -131,7 +131,7 @@ To set up your project, create a new .html document. Give it a title, and includ
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>Remote Command Tutorial 2</title>
+    <title>Tutorial | Using Sensors, WebSockets, and Locomotion</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- Include references to a CDN for the Axios library and the local path where lightSocket.js is saved in the <head> of your document -->
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
@@ -468,7 +468,7 @@ To set up your project, create a new .html document. Give it a title, and includ
 <html>
     <head>
         <meta charset="utf-8" />
-        <title>Remote Command Tutorial 3</title>
+        <title>Tutorial | Exploring Computer Vision</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <!-- Include references to a CDN for the Axios library and the local path where lightSocket.js is saved in the <head> of your document -->
         <script src="https://unpkg.com/axios/dist/axios.min.js"></script>  
@@ -856,7 +856,7 @@ At the bottom of the script, call `socket.Connect()`. When the connection is est
 socket.Connect();
 ```
 
-**Congratulations!** You have written another remote skill for Misty. When the document loads, the program:
+When you load the `.html` file in your browser, the program:
 * connects with Misty
 * sends a `GetLearnedFaces` command and checks whether your name is on the list of faces Misty already knows
 * subscribes to the `ComputerVision` WebSocket to receive messages when Misty is commanded to `StartFaceRecognition` 
@@ -886,7 +886,7 @@ To set up your project, create a new HTML document. Give it a title, and include
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>Remote Command Tutorial 4</title>
+    <title>Tutorial | Introduction to Mapping</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- Include references to a CDN for the Axios library and the local path where lightSocket.js is saved in the <head> of your document -->
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
@@ -1465,7 +1465,7 @@ To set up your project, create a new HTML document. Give it a title and include 
 <html>
 <head>
     <meta charset="utf-8" />
-    <title>Remote Command Tutorial 5</title>
+    <title>Tutorial | Taking Pictures</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- Include references to a CDN for the Axios library and the local path where lightSocket.js is saved in the <head> of your document -->
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>

--- a/src/content/docs/skills/tools.md
+++ b/src/content/docs/skills/tools.md
@@ -11,7 +11,7 @@ order: 6
 
 The Misty Skill Runner web tool is a graphic interface for some of the skill-management actions that you would otherwise need to handle via a REST client. 
 
-Access to Skill Runner is currently limited to a small group of field trial robot testers. If you'd like to be a part of our Misty II Field Trial, be sure to [apply here](https://docs.google.com/forms/d/e/1FAIpQLSdN_Jvs-HFtzQG4ysFWAMJ1ou5yltmSklYzxdcVplzMzUBMlw/viewform?usp=sf_link)
+Access to Skill Runner is currently limited to a small group of field trial robot testers. If you'd like to be a part of our Misty II Field Trial, be sure to [apply here](https://docs.google.com/forms/d/e/1FAIpQLSdN_Jvs-HFtzQG4ysFWAMJ1ou5yltmSklYzxdcVplzMzUBMlw/viewform?usp=sf_link).
 
 ![Skill runner home page](../../../assets/images/skill-runner.png)
 

--- a/src/content/docs/skills/tools.md
+++ b/src/content/docs/skills/tools.md
@@ -29,7 +29,7 @@ To use Skill Runner to upload and run a skill, follow the steps below.
 
 ## Visual Studio Code Extension
 
-You can use the Misty skills extension for [Visual Studio Code](https://code.visualstudio.com/) to aid in local skill development. This extension provides a list of the available methods for local skills. 
+You can use the Misty skills extension for [Visual Studio Code](https://code.visualstudio.com/) to aid in skill development. This extension provides a list of the available methods in Misty's on-robot JavaScript API.
 
 Access to the Misty skills extension is currently limited to a small group of field trial robot testers. If you are a field trial tester, you can access your extension download in the Field Trials section of the [Community forums](https://community.mistyrobotics.com/). 
 

--- a/src/content/index.md
+++ b/src/content/index.md
@@ -9,9 +9,10 @@ order: 1
 
 When you write code for Misty, you can quickly build skills that make use of the unique characteristics of an autonomous, roaming robot with personality.
 
-What’s a skill? A skill is your JavaScript app, running on the robot. When you write a skill, you:
+What’s a skill? A skill is code you write to make Misty do something. When you write a skill, you:
+
 1. Take some of Misty’s sensory data (vision, audio, touch, distance, etc.).
-2. Process that data on the robot using Misty’s API or send it off to a cloud service.
+2. Process that data using Misty’s API or send it off to a cloud service.
 3. Have Misty do something in response:
    * drive to check out a sound
    * express amusement
@@ -19,5 +20,6 @@ What’s a skill? A skill is your JavaScript app, running on the robot. When you
    * or anything you like
 
 There are two basic types of skill architecture:
-* [**Local**](./docs/skills/local-skill-architecture). You upload your code to the robot, and it runs internally on Misty. Local skills can also interact with external data, such as cloud calls and non-Misty API calls.
-* [**Remote**](./docs/skills/remote-command-architecture). Your code runs on an external device (say, in desktop browser or on a Raspberry Pi) and not onboard the robot. 
+
+* [**On-Robot JavaScript API Architecture**](./docs/skills/local-skill-architecture). You write code using Misty's JavaScript API and upload it to the robot. This code runs internally on Misty and can interact with external data, such as cloud calls and non-Misty API calls.
+* [**REST API & WebSocket Architecture**](./docs/skills/remote-command-architecture). Your code runs on an external device (say, in desktop browser or on a Raspberry Pi) and not onboard the robot.


### PR DESCRIPTION
Initial pass at updating docs to use new skills verbiage.  Includes changes to styling to allow longer table of content headers in the left nav to wrap instead of disappearing when they are too long.