### PR TITLE
Fix styling inconsistencies

### DIFF
--- a/src/content/misty-i/coding-misty/local-skill-architecture.md
+++ b/src/content/misty-i/coding-misty/local-skill-architecture.md
@@ -129,7 +129,9 @@ Before registering an event callback, you can use the `AddPropertyTest()` comman
 AddPropertyTest(string eventName, string property, string inequality, string valueAsString, string valueType);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** If you do not specify a property test, the system returns the full data object for the event. 
+{{box op="end"}}
 
 You can also use the `AddReturnProperty()` command to add any additional return property fields you may need:
 
@@ -289,7 +291,7 @@ The system supplies the following types of helper commands to assist you in writ
 
 * **Persistent Data.** To create data that persists across skills, you must use one of the following helper commands to save (set) that data to the robot or to get that data from the robot: `misty.Set()`, `misty.Get()`, `misty.Remove()`, `misty.Keys()`. Persistent data must be saved as one of these types: `string`, `bool`, `int`, or `double`. Alternately, you can serialize your data into a string using `JSON.stringify()` and parse it out again using `JSON.parse()`. Currently, any data saved to the robot this way is not automatically deleted and by default may be used across multiple skills. **Important!** Data stored via the `Set()` command does not persist across a reboot of the robot at this time.
 * **External Data.** Another type of helper command allows your skill to use data from the Internet. The `SendExternalRequest()` command allows you to obtain remote data and optionally save it to the robot and/or use it immediately. See the [External Requests](../../coding-misty/local-skill-tutorials/#external-requests) tutorial for an example of using this functionality. <!--TODO: Add link to sendexternalrequest tutorial-->
-* **Pausing and Debugging.** There are a few additional helper commands you can use to help with your skill: `misty.Pause()`, `misty.RandomPause()`, `misty.Debug()`, `misty.CancelSkill()`, and `misty.Publish()`. These commands are described in the [On-Robot JavaScript API reference documentation](../../reference/javascript-api). Note: An on-robot skill must have `BroadcastMode` set to `Verbose`, `Debug`, or `All` in the meta file for debug statements to be broadcast. By default, debug statements are set to `Off`.
+* **Pausing and Debugging.** There are a few additional helper commands you can use to help with your skill: `misty.Pause()`, `misty.RandomPause()`, `misty.Debug()`, `misty.CancelSkill()`, and `misty.Publish()`. These commands are described in the [On-Robot JavaScript API reference documentation](../../reference/javascript-api). **Note:** An on-robot skill must have `BroadcastMode` set to `Verbose`, `Debug`, or `All` in the meta file for debug statements to be broadcast. By default, debug statements are set to `Off`.
 
 ### Skill Management Commands
 
@@ -360,9 +362,12 @@ _global = _params.foo;
 misty.Debug(_global)
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** The `WriteToLog` value is optional. Any example meta files in this documentation may include additional key/value pairs that are not currently in active use and may change in the future.
+{{box op="end"}}
 
 ### Code File
+
 The `.js` code file contains the running code for your on-robot skill. A valid JavaScript code file can be even shorter than a corresponding JSON `meta` file. Here’s an example of a complete, very simple code file for an on-robot skill:
 
 ```javascript
@@ -498,4 +503,6 @@ POST http://<robot-ip-address>/api/skills/cancel
 
 It's possible to prevent this automatic cancellation by using an infinite loop in your code, but doing so can cause Misty to continue executing your skill in the background even after the skill times out or is explicitly cancelled. Currently, you can address this by including an additional `ForceCancelSkill` key in the `meta` file for the skill and setting its value to     `true`. When you do this, issuing a `CancelSkill` command forces the skill to cancel via a thrown exception and stops all background execution of the skill.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Cancelling a skill that has a `true` value for `ForceCancelSkill` in the `meta` puts Misty into a state where she may not be able to start new skills for up to 30 seconds. We recommend excluding the `ForceCancelSkill` parameter from the `meta` file for skills without infinite running logic, and avoiding this kind logic where possible.
+{{box op="end"}}

--- a/src/content/misty-i/coding-misty/local-skill-tutorials.md
+++ b/src/content/misty-i/coding-misty/local-skill-tutorials.md
@@ -206,7 +206,9 @@ Finally, we call another Misty command, `PlayAudio()`, and pass in the random fi
 misty.PlayAudio(randSound);
 ```
 
-Note: All of this logic needs to be contained within `_GetAudioList()` to ensure that it does not run until the audio list has been populated. 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** All of this logic must be contained within `_GetAudioList()` to ensure that it does not run until the audio list has been populated. 
+{{box op="end"}}
 
 Save the code file with the name `HelloWorld_PlayAudio.js`. See the documentation on using [Misty Skill Runner](../../../tools-&-apps/web-based-tools/skill-runner) or the REST API to [load your skill data onto Misty and run the skill from the browser](../../coding-misty/local-skill-architecture/#loading-amp-running-an-on-robot-skill).
 
@@ -801,15 +803,17 @@ misty.AddPropertyTest("BackTOF", "DistanceInMeters", "<", 0.5, "double");
 misty.RegisterEvent("BackTOF", "TimeOfFlight", 5000, true, "Synchronous", "f6cc6095-ae40-4507-a9ef-4c7638bf3ad5");
 ```
 
-As discussed above, the first “child” skill handles face recognition events. We start by defining a function for the callback (automatically named `_<Event>`) and passing in an argument to hold the data from the event. Within the callback, send a debug message to notify the user that the new skill has been triggered.
+As discussed above, the first "child" skill handles face recognition events. We start by defining a function for the callback (automatically named `_<Event>`) and passing in an argument to hold the data from the event. Within the callback, send a debug message to notify the user that the new skill has been triggered.
 
 ```javascript
 function _FaceRecognition(data) {
-   misty.Debug(“TriggerSkill part 2 has been triggered.”);
+   misty.Debug("TriggerSkill part 2 has been triggered.");
 }
 ```
 
-Note: Because we designated the GUID for _this_ skill (`HelloWorld_TriggerSkill2.js`) as the skill to call back in the registration call for `FaceRecognition` within our “parent” skill, this skill starts automatically when the event callback is triggered.
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Because we designated the GUID for _this_ skill (`HelloWorld_TriggerSkill2.js`) as the skill to call back in the registration call for `FaceRecognition` within our “parent” skill, this skill starts automatically when the event callback is triggered.
+{{box op="end"}}
 
 Next, define a variable, `personName` to hold the name of the face detected (or “unknown person” if the face was not recognized). You can access this information within `data.AdditionalResults`. 
 

--- a/src/content/misty-i/coding-misty/remote-command-tutorials.md
+++ b/src/content/misty-i/coding-misty/remote-command-tutorials.md
@@ -991,7 +991,7 @@ socket.Subscribe(eventName, msgType, debounceMs, property, inequality, value, [r
 
 When you call `socket.Subscribe()`, pass `"FaceRecognition"` for the `eventName` argument, pass `"FaceRecognition"` for `msgType`, pass `1000` for `debounceMS`, and pass `"_FaceRecognition"` for `eventCallback`. Pass `null` for all other arguments. 
 
-```javascriptvascript
+```javascript
 /* CALLBACKS */
 
 async function openCallback() {

--- a/src/content/misty-i/coding-misty/remote-command-tutorials.md
+++ b/src/content/misty-i/coding-misty/remote-command-tutorials.md
@@ -266,7 +266,9 @@ function openCallback() {
 }
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** You can learn more about `DriveTime` and how the parameters affect Misty’s movement in the API section of this documentation.
+{{box op="end"}}
 
 Pass the URL for the `DriveTime` command along with this `data` object to the `axios.post()` method. Use a `then()` method to handle a successful response and `catch()` to handle any errors.
 
@@ -513,7 +515,9 @@ const you = "<your-name>"
 let onList = false;
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Avoid hard-coding name values like this in real-world applications of Misty skills. Instead, create a form in the browser where users can type and send their names to Misty.
+{{box op="end"}}
 
 #### Opening a Connection
 
@@ -815,7 +819,9 @@ function _FaceRecognition(data) {
 }
 ```
 
-**Note:** This program does not handle the case where the value of `you` is on the list of known faces, but does not match the face of the person in Misty’s field of vision. This tutorial is designed to introduce the basics of face commands and `FaceRecognition` events, and does not address how to handle issues such as the above. This kind of edge case could be handled in a number of ways. For example, you could have Misty print a message that the face does not match the value stored in `you`, and then command her to learn the new face and assign it a numeric value for `FaceID`. Alternately, you could have Misty start face training and include a form in your .html document to allow the user to pass a new value for `FaceID`. The decision is yours!
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** This program does not handle the case where the value of `you` is on the list of known faces, but does not match the face of the person in Misty’s field of vision. This tutorial is designed to introduce the basics of face commands and `FaceRecognition` events, and does not address how to handle issues such as the above. This kind of edge case could be handled in a number of ways. For example, you could have Misty print a message that the face does not match the value stored in `you`, and then command her to learn the new face and assign it a numeric value for `FaceID`. Alternately, you could have Misty start face training and include a form in your .html document to allow the user to pass a new value for `FaceID`.
+{{box op="end"}}
 
 If a face is recognized, the value of the `"personName"` property is the name of the recognized person. In our case, this should also be the string stored in `you`. Inside the `if` statement, write code to print a message to greet the recognized face, unsubscribe from `"FaceRecognition"`, and issue a POST request to the endpoint for the command to `StopFacialRecognition`: `"http://" + ip + "/api/faces/recognition/stop"`.
 

--- a/src/content/misty-i/reference/javascript-api.md
+++ b/src/content/misty-i/reference/javascript-api.md
@@ -9,7 +9,9 @@ order: 1
 
 Use Misty's on-robot JavaScript API to write skills that run locally on your robot. To learn about the architecture of this API, see [On-Robot JavaScript API Architecture](../../../misty-i/coding-misty/local-skill-architecture).
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Not all of Misty's API is equally complete. You may see some commands labeled "Beta" or "Alpha" because the related hardware, firmware, or software is still under development. Feel free to use these commands, but realize they may behave unpredictably at this time.
+{{box op="end"}}
 
 ## Asset
 
@@ -35,14 +37,17 @@ misty.DeleteAudio("DeleteMe.wav");
 ```
 
 ### misty.DeleteImage
-Enables you to remove an image file from Misty that you have previously saved to her storage.
 
-**Note:** You can only delete image files that you have previously saved to Misty's storage. You cannot remove Misty's default system image files.
+Enables you to remove an image file from Misty that you have previously saved to her storage.
 
 ```javascript
 // Syntax
 misty.DeleteImage(string fileName, [int prePauseMs], [int postPauseMs]);
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** You can only delete image files that you have previously saved to Misty's storage. You cannot remove Misty's default system image files.
+{{box op="end"}}
 
 Arguments
 
@@ -59,12 +64,14 @@ misty.DeleteImage("DeleteMe.png");
 
 Lists all audio files (default system files and user-added files) currently stored on Misty.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
-
 ```javascript
 // Syntax
 misty.GetAudioList([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -88,15 +95,19 @@ Returns
    * userAddedAsset (boolean) - If `true`, the file was added by the user. If `false`, the file is one of Misty's system files.
 
 ### misty.GetImage
-Obtains a system or user-uploaded image file currently stored on Misty.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+Obtains a system or user-uploaded image file currently stored on Misty.
 
 ```javascript
 misty.GetImage(string fileName, [string callback], [bool base64 = true], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
-Arguments  
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
+Arguments
+
 * fileName (string) - The name of the image file to get, including its file type extension.
 * base64 (boolean) - Optional. Passing in `true` returns the image data as a Base64 string. Passing in `false` returns the image. Defaults to `true`. 
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
@@ -111,14 +122,17 @@ misty.GetImage("Angry.png", true);
 ```
 
 ### misty.GetImageList
-Obtains a list of the images stored on Misty.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+Obtains a list of the images stored on Misty.
 
 ```javascript
 // Syntax
 misty.GetImageList([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs])
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -256,9 +270,12 @@ misty.AddReturnProperty("EventName", "DistanceInMeters");
 
 
 ### misty.RegisterEvent - ALPHA
+
 Register to receive messages with live event data from one of Misty's sensors. 
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Sensor Event Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#sensor-event-callbacks).
+{{box op="end"}}
 
 ```javascript
 // Syntax
@@ -313,16 +330,20 @@ Returns
 
 
 ### misty.RegisterTimerEvent - ALPHA
-Creates an event that calls a callback function after a specified period of time. For an example of using this function, see the [Timer Event tutorial](../../../misty-i/coding-misty/local-skill-tutorials/#timer-events).
 
-**Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Timed or Triggered Event Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#timed-or-triggered-event-callbacks).
+Creates an event that calls a callback function after a specified period of time. For an example of using this function, see the [Timer Event tutorial](../../../misty-i/coding-misty/local-skill-tutorials/#timer-events).
 
 ```javascript
 // Syntax
 misty.RegisterTimerEvent(string eventName, int callbackTimeInMs, [bool keepAlive], [string callbackRule], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Timed or Triggered Event Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#timed-or-triggered-event-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * eventName (string) - The name for the timer event. Note that the name you give to this timer event determines the name automatically assigned to your related callback function. That is, the system sets the name of the callback function to be the same as this event name, prefixed with an underscore (`_<eventName>`). For example, for an event name of `MyTimerEvent`, your callback function must use the name `_MyTimerEvent`. 
 * callbackTimeInMs (integer) - The amount of time in milliseconds to wait before the system calls the callback function. For example, passing a value of 3000 causes the system to wait 3 seconds.
 * keepAlive (boolean) -  Optional. By default (`false`) this timer event calls your callback only once. If you pass `true`, your callback function is called in a loop, with a frequency determined by `callbackTimeInMs`. To end the loop, call the `misty.UnregisterEvent()` function in your code.
@@ -341,7 +362,13 @@ Returns
 * Data sent by the timed event. Event data must be passed into a callback function to be processed and made available for use in your skill. For more information, see [Timed or Triggered Event Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#timed-or-triggered-event-callbacks).
 
 ### misty.RegisterUserEvent - ALPHA
+
 Creates an event that calls a callback function at a point of your choosing. You trigger the event by making a REST call to the `<robot-ip-address>/api/skills/event` endpoint with the appropriate payload for the callback and/or skill.
+
+```javascript
+// Syntax
+misty.RegisterUserEvent(string eventName, [bool keepAlive], [string callbackRule], [string skillToCall], [int prePauseMs], [int postPauseMs])
+```
 
 Once you register the event with `misty.RegisterUserEvent()`, to trigger the event you must make a REST call to the event endpoint with a POST command:
 
@@ -360,12 +387,9 @@ With a JSON body similar to:
 
 The `UniqueId` and `EventName` values are required and must match the ID of the skill to call and the event name you used in that skill. You should place any payload data you wish to send to the skill in the `Payload` field.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Timed or Triggered Event Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#timed-or-triggered-event-callbacks).
-
-```javascript
-// Syntax
-misty.RegisterUserEvent(string eventName, [bool keepAlive], [string callbackRule], [string skillToCall], [int prePauseMs], [int postPauseMs])
-```
+{{box op="end"}}
 
 Arguments
 * eventName (string) - The name for the event. Note that the name you give to this event determines the name automatically assigned to your related callback function. That is, the system sets the name of the callback function to be the same as this event name, prefixed with an underscore (`_<eventName>`). For example, for an event name of `MyUserEvent`, your callback function must use the name `_MyUserEvent`. 
@@ -490,14 +514,17 @@ misty.PlayAudio("Play.wav", 100);
 
 Sends an HTTP request from Misty to an external server. You use `misty.SendExternalRequest()` to access resources that are available via Uniform Resource Identifiers (URIs), such as cloud-based APIs or data stored on a server in another location.
 
-**Note:** In most cases, the external server's response to requests sent from the robot must be passed into a callback function to be processed and made available for use in your skills. By default, the callback function for this command is given the same name as the command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by `misty.SendExternalRequest()`, see the [External Requests](../../../misty-i/coding-misty/local-skill-tutorials/#external-requests) tutorial.
-
 ```javascript
 // Syntax
 misty.SendExternalRequest(string method, string resource, [string authorizationType], [string token], [string arguments], [bool save], [bool applyAssetAfterSaving], [string fileName], [string contentType], [string callback], [string callbackRule], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** In most cases, the external server's response to requests sent from the robot must be passed into a callback function to be processed and made available for use in your skills. By default, the callback function for this command is given the same name as the command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by `misty.SendExternalRequest()`, see the [External Requests](../../../misty-i/coding-misty/local-skill-tutorials/#external-requests) tutorial.
+{{box op="end"}}
+
 Arguments
+
 * method (string) - The [HTTP request method](https://developer.mozilla.org/en-US/docs/web/HTTP/Methods) (e.g. `GET`, `POST`, etc.) indicating the action to perform for the resource.
 * resourceURL (string) - The full Uniform Resource Identifier of the resource, i.e. `"http://soundbible.com/grab.php?id=1949&type=mp3"`.
 * authorizationType (string) - The authentication type required to access the resource, i.e. `"OAuth 1.0"`, `"OAuth 2.0"`, or `"Bearer Token"`. Use `null` if no authentication is required.
@@ -748,11 +775,14 @@ misty.Stop();
 
 "SLAM" refers to simultaneous localization and mapping. This is a robot's ability to both create a map of the world and know where they are in it at the same time. Misty's SLAM capabilities and hardware are under development. For a step-by-step mapping exercise, see the instructions with the [Command Center](../../../tools-&-apps/web-based-tools/command-center/#navigation-alpha).
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** If you are mapping with a **Misty I**, please be aware of the following:
+
 * The USB cable connecting the headboard to the Occipital Structure Core depth sensor is known to fail in some Misty prototypes. This can cause intermittent or non-working mapping and localization functionality.
 * Misty prototypes can only create and store one map at a time, and a map must be created in a single mapping session.
 * Mapping a large room with many obstacles can consume all of the memory resources on the processor used for mapping and crash the device.
 * Some Misty I and some Misty II prototypes may generate inaccurate maps due to depth sensor calibration flaws.
+{{box op="end"}}
 
 ### misty.StartSlamStreaming
 Opens the data stream from the Occipital Structure Core depth sensor, so you can obtain image and depth data when Misty is not actively tracking or mapping.
@@ -794,18 +824,22 @@ misty.StopSlamStreaming();
 ```
 
 ### misty.TakeDepthPicture
+
 Provides the current distance of objects from Misty’s Occipital Structure Core depth sensor. Note that depending on the scene being viewed, the sensor may return a large proportion of "unknown" values in the form of `NaN` ("not a number") values.
-
-**Note:** Make sure to use `misty.StartSlamStreaming()` to open the data stream from Misty's depth sensor before using this command. Mapping or tracking does not need to be active to use this command.
-
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
 
 ```javascript
 // Syntax
 misty.TakeDepthPicture([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+Make sure to use `misty.StartSlamStreaming()` to open the data stream from Misty's depth sensor before using this command. Mapping or tracking does not need to be active to use this command.
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`_<COMMAND>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
 * skillToCall (string) - Optional. The unique id of a skill to trigger for the callback, instead of calling back into the same skill.
@@ -825,16 +859,19 @@ Returns
   - width (integer) - The width of the matrix.
 
 ### misty.TakeFisheyePicture
+
 Takes a photo using the camera on Misty’s Occipital Structure Core depth sensor.
-
-**Note:** Make sure to use `misty.StartSlamStreaming()` to open the data stream from Misty's depth sensor before using this command. Mapping or tracking does not need to be active to use this command.
-
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
 
 ```javascript
 // Syntax
 misty.TakeFisheyePicture([bool base64 = true], [string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs])
 ```
+
+Make sure to use `misty.StartSlamStreaming()` to open the data stream from Misty's depth sensor before using this command. Mapping or tracking does not need to be active to use this command.
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 * base64 (boolean) - Optional. Sending a request with `true` returns the image data as a Base64 string. Defaults to `true`. **Note:** Images generated by this command are not saved in Misty's memory. To save an image to your robot for later use, pass `true` for Base64 to obtain the image data, then pass the returned image data to `misty.SaveImage()`.
@@ -884,20 +921,22 @@ misty.FollowPath("100:250,125:275...");
 
 Obtains occupancy grid data for the most recent map Misty has generated. 
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+```javascript
+// Syntax
+misty.GetMap([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
+```
 
-**Note:** To obtain a valid response from `misty.GetMap()`, Misty must first have successfully generated a map. 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
+To obtain a valid response from `misty.GetMap()`, Misty must first have successfully generated a map. 
 
 Misty’s maps are squares that are constructed around her initial physical location when she starts mapping. When a map is complete, it is a square with Misty’s starting point at the center.
 
 The occupancy grid for the map is represented by a two-dimensional matrix. Each element in the occupancy grid represents an individual cell of space. The value of each element (0, 1, 2, or 3) indicates the nature of the space in those cells (respectively: "unknown", "open", "occupied", or "covered").
 
 Each cell corresponds to a pair of X,Y coordinates that you can use with the `misty.FollowPath()`, `misty.DriveToLocation()`, and `misty.GetSlamPath()` commands. The first cell in the first array of the occupancy grid is the origin point (0,0) for the map. The X coordinate of a given cell is the index of the array for the cell. The Y coordinate of a cell is the index of that cell within its array. 
-
-```javascript
-// Syntax
-misty.GetMap([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
-```
 
 Arguments
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
@@ -927,16 +966,21 @@ Returns
 
 Obtain a path from Misty’s current location to a specified set of X,Y coordinates. Pass the waypoints this command returns to the `path` parameter of `misty.FollowPath()` for Misty to follow this path to the desired location.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
-
-**Important!** Make sure to call `misty.StartTracking()` to start Misty tracking her location before using this command, and call `misty.StopTracking()` to stop Misty tracking her location after using this command.
-
 ```javascript
 // Syntax
 misty.GetSlamPath(double X, double Y, [string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Make sure to call `misty.StartTracking()` to start Misty tracking her location before using this command, and call `misty.StopTracking()` to stop Misty tracking her location after using this command.
+{{box op="end"}}
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * X (double) - The X coordinate of the destination.
 * Y (double) - The Y coordinate of the destination.
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
@@ -955,9 +999,12 @@ Returns
 * Result (array) - An array containing integer pairs. Each pair specifies the X,Y coordinates for a waypoint on the path. With Misty's on-robot JavaScript API, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks) for more information.
 
 ### misty.GetSlamStatus - ALPHA
+
 Obtains values representing Misty's current activity and sensor status.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 ```javascript
 // Syntax
@@ -1025,20 +1072,25 @@ misty.ResetSlam();
 ```
 
 ### misty.StartMapping - ALPHA
-Starts Misty mapping an area.
 
-**Note:** If you are mapping with a **Misty I**, please be aware of the following:
-* The USB cable connecting the headboard to the Occipital Structure Core depth sensor is known to fail in some Misty prototypes. This can cause intermittent or non-working mapping and localization functionality.
-* Misty prototypes can only create and store one map at a time, and a map must be created in a single mapping session.
-* Mapping a large room with many obstacles can consume all of the memory resources on the processor used for mapping and crash the device.
-* Some Misty I and some Misty II prototypes may generate inaccurate maps due to depth sensor calibration flaws.
+Starts Misty mapping an area.
 
 ```javascript
 // Syntax
 misty.StartMapping([int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** If you are mapping with a **Misty I**, please be aware of the following:
+
+* The USB cable connecting the headboard to the Occipital Structure Core depth sensor is known to fail in some Misty prototypes. This can cause intermittent or non-working mapping and localization functionality.
+* Misty prototypes can only create and store one map at a time, and a map must be created in a single mapping session.
+* Mapping a large room with many obstacles can consume all of the memory resources on the processor used for mapping and crash the device.
+* Some Misty I and some Misty II prototypes may generate inaccurate maps due to depth sensor calibration flaws.
+{{box op="end"}}
+
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -1160,16 +1212,20 @@ misty.ForgetFace("John");
 ```
 
 ### misty.GetKnownFaces
-Obtains a list of the names of faces on which Misty has been successfully trained.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+Obtains a list of the names of faces on which Misty has been successfully trained.
 
 ```javascript
 // Syntax
 misty.GetKnownFaces([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
 * skillToCall (string) - Optional. The unique id of a skill to trigger for the callback, instead of calling back into the same skill.
@@ -1318,14 +1374,16 @@ misty.StopRecordingAudio();
 
 Takes a photo with Misty’s 4K camera.
 
-**Note:** When you call the `misty.TakePicture()` command immediately after using the camera to record a video, there may be a few seconds delay before Misty takes the photograph.
-
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
-
 ```javascript
 // Syntax
 misty.TakePicture([bool base64 = true], [string fileName], [int width], [int height], [bool displayOnScreen = false], [bool overwriteExisting = false], [string callback = _TakePicture()], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
+
+When you call the `misty.TakePicture()` command immediately after using the camera to record a video, there may be a few seconds delay before Misty takes the photograph.
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -1356,18 +1414,21 @@ Returns
    * Width (integer) - The width of the image in pixels.
 
 ### misty.StartRecordingVideo - BETA
+
 Starts recording video with Misty's 4K Camera. Misty records videos in MP4 format at a resolution of 1080 × 1920 pixels.
-
-Use `misty.StopRecordingVideo()` to stop recording a video. Video recordings cannot be longer than 10 seconds. Misty stops recording automatically if a video reaches 10 seconds before you call `misty.StopRecordingVideo()`.
-
-Misty only saves the most recent video recording to her local storage. Recordings are saved with the filename `MistyVideo.mp4`, and this file is overwritten with each new recording. To download a video from your robot, use the [`GetRecordedVideo`](../../../misty-i/reference/rest/#getrecordedvideo-beta) REST command.
-
-**Note:** When you call the `misty.StartRecordingVideo()` command immediately after using the RGB camera to take a picture, there may be a few seconds delay before Misty starts recording.
 
 ```javascript
 // Syntax
 misty.StartRecordingVideo([int prePauseMs], [int postPauseMs])
 ```
+
+Use `misty.StopRecordingVideo()` to stop recording a video. Video recordings cannot be longer than 10 seconds. Misty stops recording automatically if a video reaches 10 seconds before you call `misty.StopRecordingVideo()`.
+
+Misty only saves the most recent video recording to her local storage. Recordings are saved with the filename `MistyVideo.mp4`, and this file is overwritten with each new recording. To download a video from your robot, use the [`GetRecordedVideo`](../../../misty-i/reference/rest/#getrecordedvideo-beta) REST command.
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** When you call the `misty.StartRecordingVideo()` command immediately after using the RGB camera to take a picture, there may be a few seconds delay before Misty starts recording.
+{{box op="end"}}
 
 Arguments
 
@@ -1436,12 +1497,14 @@ misty.CancelSkill("c3f9b33b-d895-48cf-8f15-cdcf5a866bde");
 
 Obtains a list of the skills currently running on Misty.
 
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
-
 ```javascript
 //Syntax
 misty.GetRunningSkills([string callback], [string callbackRule], [string skillToCall], [int prePauseMs], [int PostPause])
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -1490,14 +1553,16 @@ misty.RunSkill("bb20ff02-edac-475c-af0c-a06e81e5dc50");
 
 Publishes a string to subscribers of the `SkillData` named object. Use this method to print debug messages to the console in your web browser when you use Skill Runner.
 
-You can think of `misty.Debug()` as the Misty version of `console.log()`. When you use Skill Runner to run a skill, the web page subscribes to the `SkillData` named object via Misty's WebSocket connection. This allows Misty to print error messages, debug messages, and other skill data to the console in your web browser. Use `misty.Debug()` to print your own messages to the console.
-
-**Note:** Data you pass into the `misty.Debug()` message must be a string. To send a data object, you can serialize your data into a string and parse it out on the client side of the `SkillData` subscription. If `BroadcastMode` is set to `off` in the meta file for a skill, the skill does not publish debug data.
-
 ```javascript
 // Syntax
 misty.Debug(string data, [int prePauseMs], [int postPauseMs]);
 ```
+
+You can think of `misty.Debug()` as the Misty version of `console.log()`. When you use Skill Runner to run a skill, the web page subscribes to the `SkillData` named object via Misty's WebSocket connection. This allows Misty to print error messages, debug messages, and other skill data to the console in your web browser. Use `misty.Debug()` to print your own messages to the console.
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Data you pass into the `misty.Debug()` message must be a string. To send a data object, you can serialize your data into a string and parse it out on the client side of the `SkillData` subscription. If `BroadcastMode` is set to `off` in the meta file for a skill, the skill does not publish debug data.
+{{box op="end"}}
 
 Arguments
 
@@ -1727,15 +1792,17 @@ misty.ForgetWifi("MyHomeWifi")
 
 Obtains a list of local WiFi networks and basic information regarding each.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
-
-
 ```javascript
 // Syntax
 misty.GetAvailableWifiNetworks([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
 * skillToCall (string) - Optional. The unique id of a skill to trigger for the callback, instead of calling back into the same skill.
@@ -1754,18 +1821,21 @@ Returns
    * SignalStrength (integer) - A numeric value for the strength of the network.
    * IsSecure (boolean) - Returns `true` if the network is secure. Otherwise, `false`.
 
-<!-- misty.GetBatteryLevel -->
 ### misty.GetBatteryLevel
-Obtains Misty's current battery level, along with other information about the battery.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+Obtains Misty's current battery level, along with other information about the battery.
 
 ```javascript
 // Syntax
 misty.GetBatteryLevel([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
 * skillToCall (string) - Optional. The unique id of a skill to trigger for the callback, instead of calling back into the same skill.
@@ -1797,16 +1867,20 @@ Returns
   * voltage (double)
 
 ### misty.GetDeviceInformation
-Obtains device-related information for the robot.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+Obtains device-related information for the robot.
 
 ```javascript
 // Syntax
 misty.GetDeviceInformation([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
 * skillToCall (string) - Optional. The unique id of a skill to trigger for the callback, instead of calling back into the same skill.
@@ -1835,16 +1909,20 @@ Returns
    * windowsOSVersion - The version of Windows IoT Core running on the robot.
 
 ### misty.GetHelp
-Obtains information about a specified API command. Calling `misty.GetHelp()` with no parameters returns a list of all the API commands that are available.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+Obtains information about a specified API command. Calling `misty.GetHelp()` with no parameters returns a list of all the API commands that are available.
 
 ```javascript
 // Syntax
 misty.GetHelp([string endpointName], [string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * endpointName (string) - Optional. A command in `"Api.<COMMAND>"` format eg: `"Api.GetAudioList"`. If no command name is specified, calling `misty.GetHelp()` returns a list of all  API commands.
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
@@ -1865,12 +1943,14 @@ Returns
 
 Obtains the robot's most recent log files. Note that log file data is stored for a maximum of 7 days.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
-
 ```javascript
 // Syntax
 misty.GetLogFile([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called. 
@@ -1940,7 +2020,10 @@ If Misty's log level is set to `Info`:
 | Error  |    &#x2713;      |&#x2713;             |
 | Remote |    &#x2713;      |&#x2713;             |
 
+
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -1963,12 +2046,14 @@ Returns
 
 Obtains Misty's list of saved network IDs.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
-
 ```javascript
 // Syntax
 misty.GetSavedWifiNetworks([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -2014,14 +2099,18 @@ Example JSON object for a saved WiFi network:
 
 Obtains information about a specified WebSocket class. Calling `misty.GetWebsocketNames()` without specifying a class returns information about all of Misty’s available WebSocket connections.
 
-**Note:** For more detailed information about each of Misty’s WebSocket connections, see [Sensor & Skill Data Types](../../../misty-i/reference/sensor-data/).
-
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
-
 ```javascript
 // Syntax
 misty.GetSavedWifiNetworks([string websocketClass], [string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
+
+{{box op="start" cssClass="boxed tipBox"}}
+**Tip:** For more detailed information about each of Misty’s WebSocket connections, see [Sensor & Skill Data Types](../../../misty-i/reference/sensor-data/).
+{{box op="end"}}
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Parameters
 

--- a/src/content/misty-i/reference/javascript-api.md
+++ b/src/content/misty-i/reference/javascript-api.md
@@ -27,6 +27,7 @@ misty.DeleteAudio(string fileName, [int prePauseMs], [int postPauseMs]);
 ```
 
 Arguments
+
 * fileName (string) - The name of the file to delete, including its file type extension.
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
@@ -88,17 +89,16 @@ misty.GetAudioList();
 
 Returns
 
-<!-- TODO: review return values -->
-
 * Result (array) - Returns an array of audio file information. With Misty's on-robot JavaScript API, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks) for more information. Each item in the array contains the following:
    * Name (string) - The name of the audio file.
-   * userAddedAsset (boolean) - If `true`, the file was added by the user. If `false`, the file is one of Misty's system files.
+   * UserAddedAsset (boolean) - If `true`, the file was added by the user. If `false`, the file is one of Misty's system files.
 
 ### misty.GetImage
 
 Obtains a system or user-uploaded image file currently stored on Misty.
 
 ```javascript
+// Syntax
 misty.GetImage(string fileName, [string callback], [bool base64 = true], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
@@ -156,6 +156,7 @@ Returns
    * UserAddedAsset (boolean) - If `true`, the file was added by the user. If `false`, the file is one of Misty's system files.
 
 ### misty.SaveAudio
+
 Saves an audio file to Misty. Maximum size is 3 MB.
 
 ```javascript
@@ -164,6 +165,7 @@ misty.SaveAudio(string fileName, string dataAsByteArrayString, [bool immediately
 ```
 
 Arguments
+
 * fileName (string) - The name of the audio file. This command accepts all audio format types, however Misty currently cannot play OGG files.
 * dataAsByteArrayString (string) - The audio data, passed as a string containing a byte array.
 * immediatelyApply (boolean) - Optional. A value of `true` tells Misty to immediately play the audio file, while a value of `false` tells Misty not to play the file.
@@ -176,18 +178,19 @@ Arguments
 misty.SaveAudio("Filename.wav", "137,80,78,71,13,1...", false, false);
 ```
 
-
 ### misty.SaveImage
-Saves an image to Misty in the form of a byte array string. Optionally, proportionately reduces the size of the saved image.
 
-Valid image file types are .jpg, .jpeg, .gif, and .png. Maximum file size is 3 MB. **Note:** Images can be reduced in size but not enlarged. Because Misty does not adjust the proportions of images, for best results use an image with proportions similar to her screen (480 x 272 pixels).
+Saves an image to Misty in the form of a byte array string. Optionally, proportionately reduces the size of the saved image.
 
 ```javascript
 // Syntax
 misty.SaveImage(string fileName, string dataAsByteArrayString, [int width], [int height], [bool immediatelyApply], [bool overwriteExisting], [int prePauseMs], [int postPauseMs]
 ```
 
+Valid image file types are .jpg, .jpeg, .gif, and .png. Maximum file size is 3 MB. **Note:** Images can be reduced in size but not enlarged. Because Misty does not adjust the proportions of images, for best results use an image with proportions similar to her screen (480 x 272 pixels).
+
 Arguments
+
 * fileName (string) - The name of the image file to save.
 * dataAsByteArrayString (string) - The image data, passed as a string containing a byte array.
 * width (integer) - Optional. A whole number greater than 0 specifying the desired image width (in pixels). **Important:** To reduce the size of an image you must supply values for both `width` and `height`. Note that if you supply disproportionate values for `width` and `height`, the system uses the proportionately smaller of the two values to resize the image.
@@ -205,8 +208,8 @@ misty.SaveImage("Filename.jpg", "137,80,78,71,13,1...", 500, 1000, false, false)
 ## Event
 
 ### misty.AddPropertyTest - ALPHA
-Creates a property comparison test to specify which data the system sends for a registered event. Use property tests to filter unwanted data out of event messages.
 
+Creates a property comparison test to specify which data the system sends for a registered event. Use property tests to filter unwanted data out of event messages.
 
 ```javascript
 // Syntax
@@ -214,6 +217,7 @@ misty.AddPropertyTest(string eventName, string property, string inequality, stri
 ```
 
 Arguments
+
 * eventName (string) - The name of the event to create a property comparison test for.
 * property (string) - The property of the event to compare. For the full list of properties for each event, see [Sensor & Skill Data Types](../../../misty-i/reference/sensor-data/).
 * inequality (string) - The comparison operator to use in the property comparison test, passed as a string. Accepts `"=>"`, `"=="`, `"!=="`, `">"`, `"<"`, `">="`, `"<="`, `"exists"`, `"empty"`, or `"delta"`.
@@ -228,6 +232,7 @@ misty.AddPropertyTest("EventName", "SensorPosition", "==", "Back", "string");
 ```
 
 ### misty.AddReturnProperty - ALPHA
+
 Adds an additional return property field for a registered event.
 
 ```javascript
@@ -258,6 +263,7 @@ function _Bumped(data) {
 ```
 
 Arguments
+
 * eventName (string) - The name of the event to add a return property field for.
 * eventProperty (string) - The additional property to return.
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
@@ -273,16 +279,17 @@ misty.AddReturnProperty("EventName", "DistanceInMeters");
 
 Register to receive messages with live event data from one of Misty's sensors. 
 
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Sensor Event Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#sensor-event-callbacks).
-{{box op="end"}}
-
 ```javascript
 // Syntax
 misty.RegisterEvent(string eventName, string messageType, int debounce, [bool keepAlive = false], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Sensor Event Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#sensor-event-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * eventName (string) - Sets an event name (of your choice) for the registered event. The name of the callback function is set automatically to be the same as your event name, prefixed with an underscore (`_<eventName>`). 
 * messageType (string) - The name of the data stream to register for events from. Matches the predefined `Type` property value for the data stream as listed [here](../../../misty-i/reference/sensor-data).
 * debounce (integer) - Sets the frequency in milliseconds with which event data is sent. 
@@ -377,6 +384,7 @@ POST <robot-ip-address>/api/skills/event
 ```
 
 With a JSON body similar to:
+
 ```json
 {
     "UniqueId" : "b307c917-beb8-47e8-9bbf-1c57e8cd4d4b",
@@ -392,6 +400,7 @@ The `UniqueId` and `EventName` values are required and must match the ID of the 
 {{box op="end"}}
 
 Arguments
+
 * eventName (string) - The name for the event. Note that the name you give to this event determines the name automatically assigned to your related callback function. That is, the system sets the name of the callback function to be the same as this event name, prefixed with an underscore (`_<eventName>`). For example, for an event name of `MyUserEvent`, your callback function must use the name `_MyUserEvent`. 
 * keepAlive (bool) - Optional. By default (`false`) the event is triggered only once. If you pass `true`, you can trigger the event repeatedly. To remove this event, call the `misty.UnregisterEvent()` function in your code.
 * callbackRule (string) - Optional. By default (`Synchronous`) the system runs the triggered callback concurrently with any other running threads. Other values are `Override` and `Abort`. `Override` tells the system to run the new callback thread but to stop running commands on any other threads, including the thread the callback was called within. The system only runs the thread the callback was triggered in, once the callback comes back. `Abort` tells the system to ignore the new callback thread if the skill is still doing work on any other threads (including the original thread the callback was called within). 
@@ -409,6 +418,7 @@ Returns
 * Data sent by the user event. Event data must be passed into a callback function to be processed and made available for use in your skill. For more information, see [Timed or Triggered Event Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#timed-or-triggered-event-callbacks).
 
 ### misty.UnregisterAllEvents - ALPHA
+
 Unregisters from all events for the skill in which this command is called.
 
 ```javascript
@@ -417,6 +427,7 @@ misty.UnregisterAllEvents([int prePauseMs], [int postPauseMs])
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -426,6 +437,7 @@ misty.UnregisterAllEvents();
 ```
 
 ### misty.UnregisterEvent - ALPHA
+
 Unregisters from a specified event.
 
 ```javascript
@@ -467,14 +479,15 @@ misty.ChangeLED(0, 0, 0);
 ```
 
 ### misty.DisplayImage
-Displays an image on Misty's screen. Optionally, `misty.DisplayImage()` can display an image for a specific length of time and/or transparently overlay an image on Misty's eyes. You can use the [`SaveImage`](../../../misty-i/reference/rest/#saveimage-byte-array-string-) command in Misty's REST API to upload images to Misty.
 
-Note that it's not possible for a custom image to overlay another custom image. Misty's eyes always appear as the base image, behind an overlay.
+Displays an image on Misty's screen. Optionally, `misty.DisplayImage()` can display an image for a specific length of time and/or transparently overlay an image on Misty's eyes. You can use the [`SaveImage`](../../../misty-i/reference/rest/#saveimage-byte-array-string-) command in Misty's REST API to upload images to Misty.
 
 ```javascript
 // Syntax
 misty.DisplayImage(string fileName, [double timeoutSeconds], [double alpha], [int prePauseMs], [int postPauseMs])
 ```
+
+Note that it's not possible for a custom image to overlay another custom image. Misty's eyes always appear as the base image, behind an overlay.
 
 Arguments
 
@@ -490,6 +503,7 @@ misty.DisplayImage("Happy.png");
 ```
 
 ### misty.PlayAudio
+
 Plays an audio clip that has been previously saved to Misty's storage.
 
 ```javascript
@@ -498,6 +512,7 @@ misty.PlayAudio(string fileName, [int volume], [int prePauseMs], [int postPauseM
 ```
 
 Arguments
+
 * fileName (string) - The name of the file to play.
 * volume (integer) - Optional. A value between 0 and 100  for the loudness of the audio clip. 0 is silent, and 100 is full volume. By default, the system volume is set to 100.
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
@@ -546,9 +561,14 @@ Returns
 
 ## Movement
 
-<!-- misty.Drive --> 
 ### misty.Drive
+
 Drives Misty forward or backward at a specific speed until cancelled. Call `misty.Stop()` to cancel driving. 
+
+```javascript
+// Syntax
+misty.Drive(double linearVelocity, double angularVelocity, [int prePauseMs], [int postPauseMs]);
+```
 
 When using the `misty.Drive()` command, it helps to understand how linear velocity (speed in a straight line) and angular velocity (speed and direction of rotation) work together:
 
@@ -558,12 +578,8 @@ When using the `misty.Drive()` command, it helps to understand how linear veloci
 * Linear velocity (0) and angular velocity (100) = rotating counter-clockwise at full speed.
 * Linear velocity (non-zero) and angular velocity (non-zero) = Misty drives in a curve.
 
-```javascript
-// Syntax
-misty.Drive(double linearVelocity, double angularVelocity, [int prePauseMs], [int postPauseMs]);
-```
-
 Arguments
+
 * linearVelocity (double) - A percent value that sets the speed for Misty when she drives in a straight line. Default value range is from -100 (full speed backward) to 100 (full speed forward).
 * angularVelocity (double) - A percent value that sets the speed and direction of Misty's rotation. Default value range is from -100 (full speed rotation clockwise) to 100 (full speed rotation counter-clockwise). **Note:** For best results when using angular velocity, we encourage you to experiment with using small positive and negative values to observe the effect on Misty's movement.
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
@@ -575,7 +591,13 @@ misty.Drive(0, 0);
 ```
 
 ### misty.DriveTime
+
 Drives Misty forward or backward at a set speed, with a given rotation, for a specified amount of time.
+
+```javascript
+// Syntax
+misty.DriveTime(double linearVelocity, double angularVelocity, int timeMs, [double degree], [int prePauseMs], [int postPauseMs]);
+```
 
 When using the `misty.DriveTime()` command, it helps to understand how linear velocity (speed in a straight line) and angular velocity (speed and direction of rotation) work together:
 
@@ -585,19 +607,14 @@ When using the `misty.DriveTime()` command, it helps to understand how linear ve
 * Linear velocity (0) and angular velocity (100) = rotating counter-clockwise at full speed.
 * Linear velocity (non-zero) and angular velocity (non-zero) = Misty drives in a curve.
 
-```javascript
-// Syntax
-misty.DriveTime(double linearVelocity, double angularVelocity, int timeMs, [double degree], [int prePauseMs], [int postPauseMs]);
-```
-
 Arguments
 
-- linearVelocity (double) - A percent value that sets the speed for Misty when she drives in a straight line. Default value range is from -100 (full speed backward) to 100 (full speed forward).
-- angularVelocity (double) - A percent value that sets the speed and direction of Misty's rotation. Default value range is from -100 (full speed rotation clockwise) to 100 (full speed rotation counter-clockwise). **Note:** For best results when using angular velocity, we encourage you to experiment with using small positive and negative values to observe the effect on Misty's movement.
-- timeMs (integer) - A value in milliseconds that specifies the duration of movement. Misty will not drive if you pass in a value of less than 100 for this argument.
-- degree (double) - (optional) The number of degrees to turn. **Note:** Supplying a `degree` value recalculates linear velocity.
-- prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
-- postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
+* linearVelocity (double) - A percent value that sets the speed for Misty when she drives in a straight line. Default value range is from -100 (full speed backward) to 100 (full speed forward).
+* angularVelocity (double) - A percent value that sets the speed and direction of Misty's rotation. Default value range is from -100 (full speed rotation clockwise) to 100 (full speed rotation counter-clockwise). **Note:** For best results when using angular velocity, we encourage you to experiment with using small positive and negative values to observe the effect on Misty's movement.
+* timeMs (integer) - A value in milliseconds that specifies the duration of movement. Misty will not drive if you pass in a value of less than 100 for this argument.
+* degree (double) - (optional) The number of degrees to turn. **Note:** Supplying a `degree` value recalculates linear velocity.
+* prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
+* postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
 ```javascript
 // Example
@@ -605,6 +622,7 @@ misty.DriveTime(0, 0, 0);
 ```
 
 ### misty.DriveTrack
+
 Drives Misty left, right, forward, or backward, depending on the track speeds specified for the individual tracks.
 
 ```javascript
@@ -633,6 +651,7 @@ misty.Halt([int prePauseMs], [int postPauseMs])
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -642,6 +661,7 @@ misty.Halt();
 ```
 
 ### misty.MoveHeadDegrees
+
 Moves Misty's head in one of three axes (tilt, turn, or up-down). **Note:** For Misty I, the `misty.MoveHeadDegrees()` command can only control the up-down movement of Misty's head.
 
 ```javascript
@@ -720,6 +740,7 @@ misty.SetHeadDegrees(string axis, double degrees, double velocity, [int prePause
 ```
 
 Arguments
+
 * axis (string) - The axis to change. Values are `"yaw"` (turn), `"pitch"` (up-and-down), or `"roll"` (tilt). Passing a value of `"yaw"` or `"roll"` in a skill running on Misty I robots does nothing.  
 * degrees (double) - Indicates the degree to move Misty’s head to along the given axis. The value range for pitch is -9.5 (fully up) to 35.0 (fully down); for roll, -43.0 (fully left) to 43.0 (fully right); for yaw, -90.0 (fully right) to 90.0 (fully left). Note that due to normal variations in the range of head motion available to each robot, the minimum and maximum values for your Misty may differ slightly from the values listed here. 
 * velocity (double) - The speed of the head movement. Value range: 0 to 100.
@@ -741,6 +762,7 @@ misty.SetHeadRadians(string axis, double position, double velocity, [int prePaus
 ```
 
 Arguments
+
 * axis (string) - The axis to change. Values are `"yaw"` (turn), `"pitch"` (up-and-down), or `"roll"` (tilt). Passing a value of `"yaw"` or `"roll"` in a skill running on Misty I robots does nothing.
 * position (double) - Indicates the radian to move Misty’s head to along the given axis. The value range for pitch is -0.1662 (fully up) to 0.6094 (fully down); for roll, -0.75 (fully left) to 0.75 (fully right); for yaw, -1.57 (fully right) to 1.57 (fully left). Note that due to normal variations in the range of head motion available to each robot, the minimum and maximum values for your Misty may differ slightly from the values listed here.
 * velocity (double) - The speed of the head movement. Value range: 0 to 100.
@@ -753,6 +775,7 @@ misty.SetHeadRadians("yaw", 1.5708, 0);
 ```
 
 ### misty.Stop
+
 Stops Misty's movement.
 
 ```javascript
@@ -769,8 +792,6 @@ Arguments
 misty.Stop();
 ```
 
-
-
 ## Navigation
 
 "SLAM" refers to simultaneous localization and mapping. This is a robot's ability to both create a map of the world and know where they are in it at the same time. Misty's SLAM capabilities and hardware are under development. For a step-by-step mapping exercise, see the instructions with the [Command Center](../../../tools-&-apps/web-based-tools/command-center/#navigation-alpha).
@@ -785,16 +806,20 @@ misty.Stop();
 {{box op="end"}}
 
 ### misty.StartSlamStreaming
-Opens the data stream from the Occipital Structure Core depth sensor, so you can obtain image and depth data when Misty is not actively tracking or mapping.
 
-**Important!** Always use `misty.StopSlamStreaming()` to close the depth sensor data stream after sending commands that use Misty's Occipital Structure Core depth sensor. Calling `misty.StopSlamStreaming()` turns off the laser in the depth sensor and lowers Misty's power consumption. Note that Misty's 4K camera may not work while the depth sensor data stream is open.
+Opens the data stream from the Occipital Structure Core depth sensor, so you can obtain image and depth data when Misty is not actively tracking or mapping.
 
 ```javascript
 // Syntax
 misty.StartSlamStreaming([int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Important!** Always use `misty.StopSlamStreaming()` to close the depth sensor data stream after sending commands that use Misty's Occipital Structure Core depth sensor. Calling `misty.StopSlamStreaming()` turns off the laser in the depth sensor and lowers Misty's power consumption. Note that Misty's 4K camera may not work while the depth sensor data stream is open.
+{{box op="end"}}
+
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -804,16 +829,20 @@ misty.StartSlamStreaming();
 ```
 
 ### misty.StopSlamStreaming
-Closes the data stream from the Occipital Structure Core depth sensor. Calling this command turns off the laser in the depth sensor and lowers Misty's power consumption.
 
-**Important!** Always use this command to close the depth sensor data stream after using `misty.StartSlamStreaming()` and any commands that use Misty's Occipital Structure Core depth sensor. Note that Misty's 4K camera may not work while the depth sensor data stream is open.
+Closes the data stream from the Occipital Structure Core depth sensor. Calling this command turns off the laser in the depth sensor and lowers Misty's power consumption.
 
 ```javascript
 // Syntax
 misty.StopSlamStreaming([int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Always use this command to close the depth sensor data stream after using `misty.StartSlamStreaming()` and any commands that use Misty's Occipital Structure Core depth sensor. Note that Misty's 4K camera may not work while the depth sensor data stream is open.
+{{box op="end"}}
+
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this 
 command, `postPauseMs` is not used.
@@ -853,10 +882,10 @@ misty.TakeDepthPicture();
 
 Returns
 
-- Result (object) - An object containing depth information about the image matrix, with the following fields. With Misty's on-robot JavaScript API, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks) for more information.
-  - height (integer) - The height of the matrix.
-  - image (array) - A matrix of size `height` x `width` containing individual values of type float. Each value is the distance in millimeters from the sensor for each pixel in the captured image. For example, if you point the sensor at a flat wall 2 meters away, most of the values in the matrix should be around 2000. Note that as the robot moves further away from a scene being viewed, each pixel value will represent a larger surface area. Conversely, if it moves closer, each pixel value will represent a smaller area.
-  - width (integer) - The width of the matrix.
+* Result (object) - An object containing depth information about the image matrix, with the following fields. With Misty's on-robot JavaScript API, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks) for more information.
+  * height (integer) - The height of the matrix.
+  * image (array) - A matrix of size `height` x `width` containing individual values of type float. Each value is the distance in millimeters from the sensor for each pixel in the captured image. For example, if you point the sensor at a flat wall 2 meters away, most of the values in the matrix should be around 2000. Note that as the robot moves further away from a scene being viewed, each pixel value will represent a larger surface area. Conversely, if it moves closer, each pixel value will represent a smaller area.
+  * width (integer) - The width of the matrix.
 
 ### misty.TakeFisheyePicture
 
@@ -874,6 +903,7 @@ Make sure to use `misty.StartSlamStreaming()` to open the data stream from Misty
 {{box op="end"}}
 
 Arguments
+
 * base64 (boolean) - Optional. Sending a request with `true` returns the image data as a Base64 string. Defaults to `true`. **Note:** Images generated by this command are not saved in Misty's memory. To save an image to your robot for later use, pass `true` for Base64 to obtain the image data, then pass the returned image data to `misty.SaveImage()`.
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`_<COMMAND>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
@@ -888,26 +918,28 @@ misty.TakeFisheyePicture(true);
 
 Returns
 
-- Result (object) -  An object containing image data and meta information. With Misty's on-robot JavaScript API, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks) for more information.
-  - base64 (string) - A string containing the Base64-encoded image data.
-  - format (string) - The type and format of the image returned.
-  - height (integer) - The height of the picture in pixels.
-  - name (string) - The name of the picture.
-  - width (integer) - The width of the picture in pixels.
+* Result (object) -  An object containing image data and meta information. With Misty's on-robot JavaScript API, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks) for more information.
+  * base64 (string) - A string containing the Base64-encoded image data.
+  * format (string) - The type and format of the image returned.
+  * height (integer) - The height of the picture in pixels.
+  * name (string) - The name of the picture.
+  * width (integer) - The width of the picture in pixels.
 
-
-<!-- misty.FollowPath - ALPHA -->
 ### misty.FollowPath - ALPHA
-Drives Misty on a path defined by coordinates you specify. Note that Misty must have a map and be actively tracking before starting to follow a path. Misty will not be able to successfully follow a path if unmapped obstacles are in her way.
 
-**Important!** Make sure to call `misty.StartTracking()` to start Misty tracking her location before using this command, and call `misty.StopTracking()` to stop Misty tracking her location after using this command.
+Drives Misty on a path defined by coordinates you specify. Note that Misty must have a map and be actively tracking before starting to follow a path. Misty will not be able to successfully follow a path if unmapped obstacles are in her way.
 
 ```javascript
 // Syntax
 misty.FollowPath(string path, [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Make sure to call `misty.StartTracking()` to start Misty tracking her location before using this command, and call `misty.StopTracking()` to stop Misty tracking her location after using this command.
+{{box op="end"}}
+
 Arguments
+
 * path (list of sets of integers) - A list containing 1 or more sets of integer pairs representing X and Y coordinates. You can obtain `path` values from a map that Misty has previously generated.  **Note:** X values specify directions forward and backward. Sideways directions are specified by Y values.
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
@@ -939,6 +971,7 @@ The occupancy grid for the map is represented by a two-dimensional matrix. Each 
 Each cell corresponds to a pair of X,Y coordinates that you can use with the `misty.FollowPath()`, `misty.DriveToLocation()`, and `misty.GetSlamPath()` commands. The first cell in the first array of the occupancy grid is the origin point (0,0) for the map. The X coordinate of a given cell is the index of the array for the cell. The Y coordinate of a cell is the index of that cell within its array. 
 
 Arguments
+
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
 * skillToCall (string) - Optional. The unique id of a skill to trigger for the callback, instead of calling back into the same skill.
@@ -1002,16 +1035,17 @@ Returns
 
 Obtains values representing Misty's current activity and sensor status.
 
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
-{{box op="end"}}
-
 ```javascript
 // Syntax
 misty.GetSlamStatus([string callback], [string callbackRule], [string skillToCall], [int prePauseMs], [int postPauseMs])
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
 * skillToCall (string) - Optional. The unique id of a skill to trigger for the callback, instead of calling back into the same skill.
@@ -1024,37 +1058,39 @@ misty.GetSlamStatus();
 ```
 
 Returns
+
 * Result (object) - A data object with the following key-value pairs. **Note:** With Misty's on-robot JavaScript API, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks) for more information.
   * Status (integer) - An integer value where each bit is set to represent a different activity mode: 1 - Idle, 2 - Exploring, 3 - Tracking, 4 - Recording, 5 - Resetting. For example, if Misty is both exploring and recording, then bits 2 and 4 would be set => 0000 1010 => Status = 10.
   * SensorStatus (integer) - A number representing the status of Misty's sensors, using the `SlamSensorStatus` enumerable.
   * RunMode (integer) - A number representing the status of Misty's navigation.
 
-```c#
+```csharp
 public enum SlamSensorStatus
 {
-Uninitialized = 0,
-Connected = 1,
-Booting = 2,
-Ready = 3,
-Disconnected = 4,
-Error = 5,
-UsbError = 6,
-LowPowerMode = 7,
-RecoveryMode = 8,
-ProdDataCorrupt = 9,
-CalibrationMissingOrInvalid = 10,
-FWVersionMismatch = 11,
-FWUpdate = 12,
-FWUpdateComplete = 13,
-FWUpdateFailed = 14,
-FWCorrupt = 15,
-EndOfFile = 16,
-UsbDriverNotInstalled = 17,
-Streaming = 18
+  Uninitialized = 0,
+  Connected = 1,
+  Booting = 2,
+  Ready = 3,
+  Disconnected = 4,
+  Error = 5,
+  UsbError = 6,
+  LowPowerMode = 7,
+  RecoveryMode = 8,
+  ProdDataCorrupt = 9,
+  CalibrationMissingOrInvalid = 10,
+  FWVersionMismatch = 11,
+  FWUpdate = 12,
+  FWUpdateComplete = 13,
+  FWUpdateFailed = 14,
+  FWCorrupt = 15,
+  EndOfFile = 16,
+  UsbDriverNotInstalled = 17,
+  Streaming = 18
 }
 ```
 
 ### misty.ResetSlam - ALPHA
+
 Resets Misty's SLAM sensors.
 
 ```javascript
@@ -1063,6 +1099,7 @@ misty.ResetSlam([int prePauseMs], [int postPauseMs]);
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -1100,6 +1137,7 @@ misty.StartMapping();
 ```
 
 ### misty.StartTracking - ALPHA
+
 Starts Misty tracking her location.
 
 ```javascript
@@ -1108,6 +1146,7 @@ misty.StartTracking([int prePauseMs], [int postPauseMs]);
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -1117,6 +1156,7 @@ misty.StartTracking();
 ```
 
 ### misty.StopMapping - ALPHA
+
 Stops Misty mapping an area.
 
 ```javascript
@@ -1125,6 +1165,7 @@ misty.StopMapping([int prePauseMs], [int postPauseMs]);
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this 
 command, `postPauseMs` is not used.
@@ -1135,6 +1176,7 @@ misty.StopMapping();
 ```
 
 ### misty.StopTracking - ALPHA
+
 Stops Misty tracking her location.
 
 ```javascript
@@ -1143,6 +1185,7 @@ misty.StopTracking([int prePauseMs], [int postPauseMs]);
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -1160,6 +1203,7 @@ Like most of us, Misty sees faces best in a well-lit area. If you want to direct
 To programmatically obtain live data streams back from Misty that include face detection and recognition data, you can [subscribe](../../coding-misty/remote-command-architecture/#getting-data-from-misty) to her FaceRecognition [WebSocket](../../reference/sensor-data). To directly observe this data, you can use the [Command Center](../../../tools-&-apps/web-based-tools/command-center/#opening-a-websocket).
 
 ### misty.CancelFaceTraining
+
 Halts face training that is currently in progress. A face training session stops automatically, so you do not need to use the `misty.CancelFaceTraining()` command unless you want to abort a training that is in progress.
 
 ```javascript
@@ -1168,6 +1212,7 @@ misty.CancelFaceTraining([int prePauseMs], [int postPauseMs]);
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -1177,6 +1222,7 @@ misty.CancelFaceTraining();
 ```
 
 ### misty.ForgetAllFaces
+
 Removes records of previously trained faces from Misty's memory.
 
 ```javascript
@@ -1185,6 +1231,7 @@ misty.ForgetAllFaces([int prePauseMs], [int postPauseMs])
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -1242,16 +1289,18 @@ Returns
 * Result (string) - A list of the names for faces that Misty has been trained to recognize. With Misty's on-robot JavaScript API, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks) for more information.
 
 ### misty.StartFaceDetection
-Initiates Misty's detection of faces in her line of vision. This command assigns each detected face a random ID.
 
-When you are done having Misty detect faces, call `misty.StopFaceDetection()`.
+Initiates Misty's detection of faces in her line of vision. This command assigns each detected face a random ID.
 
 ```javascript
 // Syntax
 misty.StartFaceDetection([int prePauseMs], [int postPauseMs]);
 ```
 
+When you are done having Misty detect faces, call `misty.StopFaceDetection()`.
+
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -1261,16 +1310,18 @@ misty.StartFaceDetection();
 ```
 
 ### misty.StartFaceRecognition
-Directs Misty to recognize a face she sees, if it is among those she has previously detected. To use this command, you must have previously used the `misty.StartFaceDetection()` command to detect and store face IDs in Misty's memory.
 
-When you are done having Misty recognize faces, call `misty.StopFaceRecognition()`.
+Directs Misty to recognize a face she sees, if it is among those she has previously detected. To use this command, you must have previously used the `misty.StartFaceDetection()` command to detect and store face IDs in Misty's memory.
 
 ```javascript
 // Syntax
 misty.StartFaceRecognition([int prePauseMs], [int postPauseMs]);
 ```
 
+When you are done having Misty recognize faces, call `misty.StopFaceRecognition()`.
+
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -1279,18 +1330,19 @@ Arguments
 misty.StartFaceRecognition();
 ```
 
-<!-- misty.StartFaceTraining - BETA -->
 ### misty.StartFaceTraining
-Starts Misty learning a face and assigns a name to that face.
 
-This process should take less than 15 seconds and will automatically stop when complete. To halt an in-progress face training, you can call `misty.CancelFaceTraining()`.
+Starts Misty learning a face and assigns a name to that face.
 
 ```javascript
 // Syntax
 misty.StartFaceTraining(string faceId, [int prePauseMs], [int postPauseMs]);
 ```
 
+This process should take less than 15 seconds and will automatically stop when complete. To halt an in-progress face training, you can call `misty.CancelFaceTraining()`.
+
 Arguments
+
 * faceId (string) - A unique string of 30 characters or less that provides a name for the face. Only alpha-numeric, `-`, and `_` are valid characters.
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
@@ -1301,6 +1353,7 @@ misty.StartFaceTraining("My_Face");
 ```
 
 ### misty.StartRecordingAudio
+
 Directs Misty to initiate an audio recording and save it with the specified file name. Misty records audio with a far-field microphone array and saves it as a byte array string. To stop recording, you must call the `misty.StopRecordingAudio()` command. If you do not call `misty.StopRecordingAudio()`, Misty automatically stops recording after 60 seconds.
 
 ```javascript
@@ -1309,6 +1362,7 @@ misty.StartRecordingAudio(string filename, [int prePauseMs], [int postPauseMs]);
 ```
 
 Arguments
+
 * fileName (string) - The name to assign to the audio recording. This parameter must include a `.wav` file type extension at the end of the string.
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
@@ -1318,8 +1372,8 @@ Arguments
 misty.StartRecordingAudio("RecordingExample.wav");
 ```
 
-
 ### misty.StopFaceDetection
+
 Stops Misty's detection of faces in her line of vision.
 
 ```javascript
@@ -1328,6 +1382,7 @@ misty.StopFaceDetection([int prePauseMs], [int postPauseMs]);
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -1337,6 +1392,7 @@ misty.StopFaceDetection();
 ```
 
 ### misty.StopFaceRecognition
+
 Stops the process of Misty recognizing a face she sees.
 
 ```javascript
@@ -1345,6 +1401,7 @@ misty.StopFaceRecognition([int prePauseMs], [int postPauseMs])
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -1354,6 +1411,7 @@ misty.StopFaceRecognition();
 ```
 
 ### misty.StopRecordingAudio
+
 Directs Misty to stop the current audio recording and saves the recording to the robot under the `fileName` name specified in the call to `misty.StartRecordingAudio()`. Use this command after calling the `misty.StartRecordingAudio()` command. If you do not call `misty.StopRecordingAudio()`, Misty automatically stops recording after 60 seconds.
 
 ```javascript
@@ -1362,6 +1420,7 @@ misty.StopRecordingAudio([int prePauseMs], [int postPauseMs]);
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -1444,12 +1503,12 @@ misty.StartRecordingVideo();
 
 Stops recording video with Misty's 4K camera.
 
-Use this command after calling `misty.StartRecordingVideo()`. Video recordings cannot be longer than 10 seconds. Misty stops recording automatically if a video reaches 10 seconds before you call this command. To download a video from your robot, use the [`GetRecordedVideo`](../../../misty-i/reference/rest/#getrecordedvideo-beta) REST command.
-
 ```javascript
 // Syntax
 misty.StopRecordingVideo([int prePauseMs], [int postPauseMs]);
 ```
+
+Use this command after calling `misty.StartRecordingVideo()`. Video recordings cannot be longer than 10 seconds. Misty stops recording automatically if a video reaches 10 seconds before you call this command. To download a video from your robot, use the [`GetRecordedVideo`](../../../misty-i/reference/rest/#getrecordedvideo-beta) REST command.
 
 Arguments
 
@@ -1474,8 +1533,8 @@ Returns
 ## Skill Management
 
 ### misty.CancelSkill
-Cancel execution a specified skill.
 
+Cancel execution a specified skill.
 
 ```javascript
 // Syntax
@@ -1599,9 +1658,6 @@ Returns
 
 * value (string, boolean, integer, or double) - The data associated with the specified key.
 
-
-
-
 ### misty.Keys - ALPHA
 
 Returns a list of all the available persistent data stored on the robot. 
@@ -1626,6 +1682,7 @@ Returns
 * keys (list) - A list of the keys and values for all available persistent data stored on the robot.
 
 ### misty.Pause - ALPHA
+
 Pause skill execution for a specified number of milliseconds.
 
 ```javascript
@@ -1634,6 +1691,7 @@ misty.Pause(int prePauseMs)
 ```
 
 Arguments
+
 * prePauseMs (integer) - The duration in milliseconds to pause skill execution.
 
 ```javascript
@@ -1645,12 +1703,12 @@ misty.Pause(1000);
 
 Writes data to the robot's internal log.
 
-Note that `misty.Publish()` writes data to the robot's internal log file, even when called in a skill with the value of `WriteToLog` set to `False` in its meta file. You can use the Command Center to download your robot's log files, or send a GET request to the REST endpoint for the [`GetLogFile`](../../../misty-i/reference/rest/#getlogfile) command.
-
 ```javascript
 // Syntax
 misty.Publish(string name, string data)
 ```
+
+Note that `misty.Publish()` writes data to the robot's internal log file, even when called in a skill with the value of `WriteToLog` set to `False` in its meta file. You can use the Command Center to download your robot's log files, or send a GET request to the REST endpoint for the [`GetLogFile`](../../../misty-i/reference/rest/#getlogfile) command.
 
 Arguments
 
@@ -1663,6 +1721,7 @@ misty.Publish("data-name", "data-value");
 ```
 
 ### misty.RandomPause - ALPHA
+
 Pause skill execution for a random duration.
 
 ```javascript
@@ -1671,6 +1730,7 @@ misty.RandomPause(int minimumDelay, int maximumDelay)
 ```
 
 Arguments
+
 * minimumDelay (integer) - The minimum duration in milliseconds to pause skill execution.
 * maximumDelay (integer) - The maximum duration in milliseconds to pause skill execution. 
 
@@ -1678,7 +1738,6 @@ Arguments
 // Example
 misty.RandomPause(1000, 2000);
 ```
-
 
 ### misty.Remove - ALPHA
 
@@ -1704,6 +1763,11 @@ misty.Remove("Key");
 
 Saves data that can be validly updated and used across threads or shared between skills.
 
+```javascript
+// Syntax
+misty.Set(string key, string value, [bool longTermStorage], [int prePauseMs], [int postPauseMs]);
+```
+
 Data saved using `misty.Set()` must be one of these types: `string`, `bool`, `int`, or `double`. Alternately, you can serialize your data into a string using `JSON.stringify()` and parse it out again using `JSON.parse()`.
 
 By default, long term data saved by the `misty.Set()` command clears from Misty's memory when Misty reboots. To change this, you need to include an additional `SkillStorageLifetime` key in the meta file for your skill. The `SkillStorageLifetime` key determines how long data saved to Misty with the `misty.Set()` command remains available for use in your skills. You can set the value of `SkillStorageLifetime` to `Skill`, `Reboot`, or `LongTerm`.
@@ -1713,11 +1777,6 @@ By default, long term data saved by the `misty.Set()` command clears from Misty'
 * `LongTerm` - The data persists across reboots and remains available until removed from the robot with the mi`sty.Remove()` command.
 
 You can safely omit the `SkillStorageLifetime` key from the meta file if you do not want to modify the default behavior of persistent data for that skill.
-
-```javascript
-// Syntax
-misty.Set(string key, string value, [bool longTermStorage], [int prePauseMs], [int postPauseMs]);
-```
 
 Arguments
 
@@ -1953,6 +2012,7 @@ misty.GetLogFile([string callback], [string callbackRule = "synchronous"], [stri
 {{box op="end"}}
 
 Arguments
+
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called. 
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
 * skillToCall (string) - Optional. The unique id of a skill to trigger for the callback, instead of calling back into the same skill.
@@ -1989,7 +2049,6 @@ If Misty's log level is set to `Debug`:
 | Error  |      &#x2713;    |  &#x2713;         |
 | Remote |       &#x2713;   |   &#x2713;        |
 
-
 If Misty's log level is set to `Info`:
 
 |    Message Type:    | Logged Locally    | Logged Remotely    |
@@ -2019,7 +2078,6 @@ If Misty's log level is set to `Info`:
 | Warn   |    &#x2713;      |              |
 | Error  |    &#x2713;      |&#x2713;             |
 | Remote |    &#x2713;      |&#x2713;             |
-
 
 {{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-i/coding-misty/local-skill-architecture/#-quot-get-quot-data-callbacks).
@@ -2209,8 +2267,8 @@ If Misty's log level is set to `Info`:
 | Error  |    &#x2713;      |&#x2713;             |
 | Remote |    &#x2713;      |&#x2713;             |
 
-
 Arguments
+
 * level (string) - The level to set the log to. Accepts `Debug`, `Info`, `Warn`, or `Error`. 
 * prePause (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.

--- a/src/content/misty-i/reference/rest.md
+++ b/src/content/misty-i/reference/rest.md
@@ -11,7 +11,9 @@ With the REST API, you can send commands to Misty from a REST client or browser.
 
 To create skills for Misty, you'll need to send commands to Misty and get data back from Misty. To send commands to Misty, you can call the REST API. To get live updating data back from Misty, you'll need to use a [WebSocket connection](../../coding-misty/remote-command-architecture#subscribing-amp-unsubscribing-to-a-websocket). You can visit the [REST-API repository on GitHub](https://github.com/MistyCommunity/REST-API) for sample code and tutorials.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Not all of Misty's API is equally complete. You may see some commands labeled "Beta" or "Alpha" because the related hardware, firmware, or software is still under development. Feel free to use these commands, but realize they may behave unpredictably at this time.
+{{box op="end"}}
 
 ## URL & Message Formats
 
@@ -43,13 +45,17 @@ If there is an issue, Misty returns an HTTP error code and error message.
 Misty comes with a set of default images that you can display onscreen and sounds that you can play through her speakers. We encourage you to get creative and use your own image and audio assets in your skills.
 
 ### DeleteAudio
+
 Enables you to remove an audio file from Misty that you have previously uploaded.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** You can only delete audio files that you have previously uploaded to Misty. You cannot remove Misty's default system audio files.
+{{box op="end"}}
 
 Endpoint: DELETE &lt;robot-ip-address&gt;/api/audio
 
 Parameters
+
 * FileName (string) - The name of the file to delete, including its file type extension.
 
 ```json
@@ -63,13 +69,17 @@ Return Values
 
 
 ### DeleteImage
-Enables you to remove an image file from Misty that you have previously uploaded.
 
+Removes an image file from Misty that you have previously uploaded.
+
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** You can only delete image files that you have previously uploaded to Misty. You cannot remove Misty's default system image files.
+{{box op="end"}}
 
 Endpoint: DELETE &lt;robot-ip-address&gt;/api/images
 
 Parameters
+
 * FileName (string) - The name of the file to delete, including its file type extension.
 
 ```json
@@ -82,20 +92,26 @@ Return Values
 * Result (boolean) - Returns `true` if there are no errors related to this command.
 
 ### GetAudioFile
+
 Obtains a system or user-uploaded audio file currently stored on Misty.
 
 Endpoint: GET &lt;robot-ip-address&gt;/api/audio?FileName={name-of-audio-file.extension}
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Because GET requests do not include payloads, the query parameter for this request must be included in the URL.
+{{box op="end"}}
+
 Parameters  
-**Note:** Because GET requests do not include payloads, the parameter for this request must be included in the URL as seen above.
-- FileName (string): The name of the audio file to get, including its file type extension.
+
+* FileName (string): The name of the audio file to get, including its file type extension.
 
 ```markup
 http://<robot-ip-address>/api/audio?FileName=ExampleAudio.mp3
 ```
 
 Return Values
-- An audio file that plays in your browser or REST client. You can save the file by manually downloading it either from your browser or from a REST client such as Postman.
+
+* An audio file that plays in your browser or REST client. You can save the file by manually downloading it either from your browser or from a REST client such as Postman.
 
 ### GetAudioList
 Lists all audio files (default system files and user-uploaded files) currently stored on Misty.
@@ -119,11 +135,14 @@ Example:
 
 `http://<robot-ip-address>/api/images?FileName=happy.png&Base64=false`
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Because GET requests do not contain payloads, the query parameter for this request must be included in the URL.
+{{box op="end"}}
+
 Parameters
 
-**Note:** Because GET requests do not contain payloads, the parameter for this request must be included in the URL as seen above.
-- FileName (string) - The name of the image file to get, including the file type extension.
-- Base64 (boolean) - Optional. Sending a request with `true` returns the image data as a downloadable Base64 string. Sending a request with `false` displays the image in your browser or REST client immediately after the image is taken. Default is `true`.
+* FileName (string) - The name of the image file to get, including the file type extension.
+* Base64 (boolean) - Optional. Sending a request with `true` returns the image data as a downloadable Base64 string. Sending a request with `false` displays the image in your browser or REST client immediately after the image is taken. Default is `true`.
 
 ```json
 {
@@ -133,12 +152,13 @@ Parameters
 ```
 
 Return Values
-- Result (object) - An object containing image data and meta information. This object is only sent if you pass `true` for Base64.
-  - base64 (string) - A string containing the Base64-encoded image data.
-  - format (string) - The type and format of the image returned.
-  - height (integer) - The height of the image in pixels.
-  - name (string) - The name of the image.
-  - width (integer) - The width of the image in pixels.
+
+* Result (object) - An object containing image data and meta information. This object is only sent if you pass `true` for Base64.
+  * base64 (string) - A string containing the Base64-encoded image data.
+  * format (string) - The type and format of the image returned.
+  * height (integer) - The height of the image in pixels.
+  * name (string) - The name of the image.
+  * width (integer) - The width of the image in pixels.
 
 ```json
 {
@@ -192,13 +212,17 @@ Return Values
 
 
 ### SaveAudio (Audio File)
+
 Saves an audio file to Misty. Maximum size is 3 MB.
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/audio
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Make sure to set the `content-type` in the header of the POST call to [`multipart/form-data`](https://developer.mozilla.org/en-US/docs/web/HTTP/Basics_of_HTTP/MIME_types#multipartform-data). Uploading files to Misty this way does _not_ work with JQuery’s AJAX, but does work with XHR (XMLHttpRequest).
+{{box op="end"}}
 
 Parameters
+
 - File (object) - The audio file to save to Misty. This command accepts all audio format types, however Misty currently cannot play OGG files.
 - FileName (string) - Optional. The name the file will have on Misty. Must include the file type extension. If unspecified, the audio file will be saved with the same name as the source file.
 - ImmediatelyApply (boolean) - Optional. A value of `true` tells Misty to immediately play the uploaded audio file, while a value of `false` tells Misty not to play the file.
@@ -211,15 +235,19 @@ Return Values
 
 
 ### SaveImage (Byte Array String)
+
 Saves an image to Misty in the form of a byte array string. Optionally, proportionately reduces the size of the saved image.
 
 Valid image file types are .jpg, .jpeg, .gif, .png. Maximum file size is 3 MB.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Images can be reduced in size but not enlarged. Because Misty does not adjust the proportions of images, for best results use an image with proportions similar to her screen (480 x 272 pixels).
+{{box op="end"}}
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/images
 
 Parameters
+
 * FileName (string) - The name of the image file to upload.
 * DataAsByteArrayString (string) - The image data, passed as a string containing a byte array.
 * Width (integer) - Optional. A whole number greater than 0 specifying the desired image width (in pixels). **Important:** To reduce the size of an image you must supply values for both `Width` and `Height`. Note that if you supply disproportionate values for `Width` and `Height`, the system uses the proportionately smaller of the two values to resize the image. 
@@ -249,9 +277,13 @@ Return Values
 
 Saves an image file to Misty. Optionally, proportionately reduces the size of the saved image.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Images can be reduced in size but not enlarged. Because Misty does not adjust the proportions of images, for best results use an image with proportions similar to her screen (480 x 272 pixels).
+{{box op="end"}}
 
-**Note:** Make sure to set the content-type in the header of the POST call to `multipart/form-data`. Uploading files to Misty this way does not work with JQuery’s AJAX, but does work with XHR (XMLHttpRequest).
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Be sure to set the content-type in the header of the POST call to `multipart/form-data`. Uploading files to Misty this way does not work with JQuery’s AJAX, but does work with XHR (XMLHttpRequest).
+{{box op="end"}}
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/images
 
@@ -511,7 +543,9 @@ Parameters
 }
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Due to normal variations in the range of head motion available to each robot, the minimum and maximum values for your Misty may differ slightly from the values listed here.
+{{box op="end"}}
 
 **Value Ranges (By Unit) for Each Direction of Head Movement**
 
@@ -551,12 +585,14 @@ Return Values
 
 "SLAM" refers to simultaneous localization and mapping. This is a robot's ability to both create a map of the world and know where they are in it at the same time. Misty's SLAM capabilities and hardware are under development. For a step-by-step mapping exercise, see the instructions with the [Command Center](../../../tools-&-apps/web-based-tools/command-center/#navigation-alpha).
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** If you are mapping with a **Misty I**, please be aware of the following:
 
 * The USB cable connecting the headboard to the Occipital Structure Core depth sensor is known to fail in some Misty prototypes. This can cause intermittent or non-working mapping and localization functionality.
 * Misty prototypes can only create and store one map at a time, and a map must be created in a single mapping session.
 * Mapping a large room with many obstacles can consume all of the memory resources on the processor used for mapping and crash the device.
 * Some Misty I and some Misty II prototypes may generate inaccurate maps due to depth sensor calibration flaws.
+{{box op="end"}}
 
 ### StartSlamStreaming
 
@@ -610,14 +646,21 @@ Return Values
 ```
 
 ### TakeFisheyePicture
+
 Takes a photo using Misty’s Occipital Structure Core depth sensor.
 
-**Important!** Make sure to use `StartSlamStreaming` to open the data stream from Misty's depth sensor before using this command, and use `StopSlamStreaming` to close the data stream after using this command.
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Make sure to use `StartSlamStreaming` to open the data stream from Misty's depth sensor before using this command, and use `StopSlamStreaming` to close the data stream after using this command.
+{{box op="end"}}
 
 Endpoint: GET &lt;robot-ip-address&gt;/api/cameras/fisheye?Base64=&lt;bool&gt;
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Because GET requests do not contain payloads, the query parameter for this request must be included in the URL.
+{{box op="end"}}
+
 Parameters  
-**Note:** Because GET requests do not contain payloads, the parameter for this request must be included in the URL as seen above.
+
 - Base64 (boolean) - Sending a request with `true` returns the image data as a downloadable Base64 string, while sending a request of `false` displays the photo in your browser or REST client immediately after it is taken. Default is `true`. **Note:** Images generated by this command are not saved in Misty's memory. To save an image to your robot for later use, pass `true` for `Base64` to obtain the image data, download the image file, then call `SaveImage` to upload and save the image to Misty.
 
 Return Values
@@ -647,6 +690,7 @@ Drives to a designated waypoint.
 Endpoint: POST &lt;robot-ip-address&gt;/api/drive/coordinates
 
 Parameters
+
 * Destination (string) - A colon-separated integer pair that represents the X and Y coordinates of the destination. **Note:** `GetMap` obtains the occupancy grid for the most recent map Misty has generated. Use this grid to determine the X and Y coordinates of the destination. The X coordinate of a given cell is the index of the array for the cell. The Y coordinate of a cell is the index of that cell within its array. 
 
 ```json
@@ -708,19 +752,27 @@ Return Values
 
 "SLAM" refers to simultaneous localization and mapping. This is a robot's ability to both create a map of the world and know where they are in it at the same time. Misty's SLAM capabilities and hardware are under development. For a step-by-step mapping exercise, see the instructions with the [Command Center](../../../tools-&-apps/web-based-tools/command-center/#navigation-alpha).
 
+
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** If you are mapping with a **Misty I**, please be aware of the following:
+
 * The USB cable connecting the headboard to the Occipital Structure Core depth sensor is known to fail in some Misty prototypes. This can cause intermittent or non-working mapping and localization functionality.
 * Misty prototypes can only create and store one map at a time, and a map must be created in a single mapping session.
 * Mapping a large room with many obstacles can consume all of the memory resources on the processor used for mapping and crash the device.
 * Some Misty I and some Misty II prototypes may generate inaccurate maps due to depth sensor calibration flaws.
+{{box op="end"}}
 
 ### GetSlamPath - ALPHA
 
 Obtain a path from Misty’s current location to a specified set of X,Y coordinates. Pass the waypoints this command returns to the path parameter of `FollowPath` for Misty to follow this path to the desired location.
 
-**Note:** `GetMap` obtains the occupancy grid for the most recent map Misty has generated. Use this grid to determine the X and Y coordinates of the destination. The X coordinate of a given cell is the index of the array for the cell. The Y coordinate of a cell is the index of that cell within its array. 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** `GetMap` obtains the occupancy grid for the most recent map Misty has generated. Use this grid to determine the X and Y coordinates of the destination. The X coordinate of a given cell is the index of the array for the cell. The Y coordinate of a cell is the index of that cell within its array.
+{{box op="end"}} 
 
-**Important!** Make sure to use `StartTracking` before using this command to have Misty start tracking her location, and use `StopTracking` to have her stop tracking her location after she arrives at the specified location.
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** You must use `StartTracking` before using this command to have Misty start tracking her location, and use `StopTracking` to have her stop tracking her location after she arrives at the specified location.
+{{box op="end"}}
 
 Endpoint: GET &lt;robot-ip-address&gt;/api/slam/path
 
@@ -802,11 +854,14 @@ Return Values
 
 Starts Misty mapping an area.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** If you are mapping with a **Misty I** or **Misty II prototype**, please be aware of the following:
+
 * The USB cable connecting the headboard to the Occipital Structure Core depth sensor is known to fail in some Misty prototypes. This can cause intermittent or non-working mapping and localization functionality.
 * Misty prototypes can only create and store one map at a time, and a map must be created in a single mapping session.
 * Mapping a large room with many obstacles can consume all of the memory resources on the processor used for mapping and crash the device.
 * Some Misty I and some Misty II prototypes may generate inaccurate maps due to depth sensor calibration flaws.
+{{box op="end"}}
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/slam/map/start
 
@@ -1020,7 +1075,9 @@ Return Values
 
 Takes a photo with Misty’s 4K camera. Optionally, saves the photo to Misty and proportionately reduces the size of the photo.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** When you call the `TakePicture` command immediately after using the RGB camera to record a video, there may be a few seconds delay before Misty takes the photograph.
+{{box op="end"}}
 
 Endpoint: GET &lt;robot-ip-address&gt;/api/cameras/rgb
 
@@ -1063,7 +1120,9 @@ Return Values
 
 Downloads Misty's most recent video recording to your browser or REST client.
 
-**Note:** Misty records videos in MP4 format at a resolution of 1080x1920 pixels. A single video may be larger than 10 megabytes and can take several seconds to download.
+{{box op="start" cssClass="boxed noteBox"}}
+Misty records videos in .mp4 format at a resolution of 1080 x 1920 pixels. A single video may be larger than 10 megabytes and can take several seconds to download.
+{{box op="end"}}
 
 Endpoint: GET &lt;robot-ip-address&gt;/api/video
 
@@ -1082,7 +1141,9 @@ Use the `StopRecordingVideo` command to stop recording a video. Video recordings
 
 Misty only saves the most recent video recording to her local storage. Recordings are saved with the filename `MistyVideo.mp4`, and this file is overwritten with each new recording.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** When you call the `StartRecordingVideo` command immediately after using the RGB camera to take a picture, there may be a few seconds delay before Misty starts recording.
+{{box op="end"}}
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/video/record/start
 
@@ -1214,9 +1275,12 @@ Return Values
 
 
 ### SaveSkillToRobot
+
 Uploads a skill to the robot and makes it immediately available for the robot to run.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** To send a file with this request, make sure to set the `content-type` in the header of the `POST` call to `multipart/form-data`.
+{{box op="end"}}
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/skills
 
@@ -1254,22 +1318,25 @@ Parameters
 Return Values
 * Result (boolean) - Returns `true` if no errors related to this request.
 
-<!-- ReloadSkills --> 
 ### ReloadSkills - ALPHA
+
 Makes all previously uploaded skills available for the robot to run and updates any skills that have been edited. **Note:** The `ReloadSkills` command runs immediately, but there may be a significant delay after the call completes before all skills are fully loaded onto the robot if there are many to load.
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/skills/reload
 
 Parameters
+
 * (None)
 
 Return Values
+
 * Result (boolean) - Returns `true` if no errors related to this request. 
 
 
 ## System
 
 ### ClearDisplayText
+
 Force-clears an error message from Misty’s display. **Note:** This command is provided as a convenience. You should not typically need to call `ClearDisplayText`.
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/text/clear
@@ -1540,7 +1607,9 @@ Return Values
 
 Obtains information about a specified WebSocket class. Calling `GetWebsocketNames` with no parameters returns information about all of Misty’s available WebSocket connections.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** For examples of subscribing to WebSocket data, see the sample skills in the MistyCommunity GitHub repo. For more detailed information about each of Misty’s WebSocket connections, see [Sensor & Skill Data Types](../../../misty-i/reference/sensor-data/).
+{{box op="end"}}
  
 Endpoint: 
 
@@ -1606,7 +1675,9 @@ Return Values
 
 Attempts to install updates for specified components of your robot. 
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Only use this command when a system update fails to update every component of your robot. Always attempt a full system update before using this command. The version numbers for individual components are returned by the `GetDeviceInformation` command. You can make sure individual components are up-to-date by comparing these version numbers to the most recent release notes on the [Misty Community](https://community.mistyrobotics.com/) site.
+{{box op="end"}}
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/system/update/component
 

--- a/src/content/misty-i/reference/sensor-data.md
+++ b/src/content/misty-i/reference/sensor-data.md
@@ -99,13 +99,17 @@ The ```SelfState``` WebSocket provides a variety of data about Misty’s current
 * SLAM status
 * sensor messages
 
+
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** There are a number of fields in the WebSocket data structure that are reserved for future use and which may be empty or contain ```null``` data:
+
 * ```Acceleration```
 * ```BumpedState```
 * ```CurrentGoal```
 * ```MentalState```
 * ```Personality```
 * ```PhysiologicalBehavior```
+{{box op="end"}}
 
 ```SelfState``` WebSocket messages are sent even if the data has not changed, as the data is sent via timed updates, instead of being triggered by events. The ```SelfState``` WebSocket can send data as frequently as every 100ms, though it is set by default to 250ms. To avoid having to handle excess data, you can change the message frequency for the WebSocket with the ```DebounceMs``` field, as shown in the ```lightSocket.js``` JavaScript helper.
 

--- a/src/content/misty-i/robot/misty-i.md
+++ b/src/content/misty-i/robot/misty-i.md
@@ -11,12 +11,16 @@ Welcome! Your Misty I Developer Edition Prototype robot has been hand-built by t
 
 For safety and care during shipping, your robot arrives with a couple of items disconnected and with the final pieces of the case removed. Please start here for some quick words of advice on setting her up. You can also [watch this video](https://youtu.be/ROqzzQRf2qI) to see the setup process directly.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Important:** While future versions of Misty will be much tougher, it’s important that you handle your Misty I Developer Edition Prototype robot with care. When carrying Misty, support the entire robot from the front and back, below the main chassis between the two tracks.
+{{box op="end"}}
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** To avoid the risk of driving Misty off a high surface, we recommend either working with the robot on the floor or temporarily elevating the wheels so the robot cannot drive. To do this, you can either place a couple of books underneath Misty between the wheels or use this handy [stand for Misty I](https://github.com/MistyCommunity/assets/blob/master/M1_Robot_Stand.STL) that you can 3D print.
-
+{{box op="end"}}
 
 ## What's in the Box?
+
 Aside from Misty herself, there are a few things to look for in her packaging:
 
 * battery
@@ -25,10 +29,12 @@ Aside from Misty herself, there are a few things to look for in her packaging:
 * USB-to-Ethernet adapter
 * FTDI cable
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Please keep all the original packaging for Misty. In case you need to ship her in the future, this packaging has been specially designed to protect these hand-built prototypes.
-
+{{box op="end"}}
 
 ## Connecting the Battery
+
 While Misty's case is open is the ideal time to connect up your robot's battery. **Before doing so, please read the following important notes:**
 
  * Always use the battery that came with Misty.
@@ -47,10 +53,12 @@ To connect Misty's battery:
 
 Once you've plugged in the battery, you can assemble Misty's case and connect the Occipital Structure Core depth sensor.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** If you want to charge the robot while it’s turned on, you’ll need to **first** let the robot fully boot up, **then** plug the power adaptor into the robot’s back.
-
+{{box op="end"}}
 
 ## Assembling Misty's Case
+
 Now that the battery is connected, you can put together the finishing pieces of Misty's case:
 
 1. Undo the two small bolts that attach the plastic logo plate to the front of Misty's chest. Remove the plate and set it and the bolts aside. ![removing the logo plate](/assets/images/faceplate_removal.jpg)
@@ -65,16 +73,23 @@ The Occipital Structure Core depth sensor is your Misty robot's main way of mapp
 1. Tucked behind Misty's faceplate, find the black USB cable with a loose end. ![loose Occipital cable](/assets/images/occipital_cable_loose.jpg)
 2. Connect the loose end of the cable into the sensor's open USB port on Misty's right side. Make sure you feel a click when inserting the cable, to ensure it is fully seated. ![Occipital cable attached](/assets/images/occipital_cable_attached.jpg)
 
-**Note**: When the Occipital Structure Core depth sensor is starting up, the LED in the depth sensor will flash blue and red for up to 10 seconds. Once the depth sensor is fully online, the LED should be solid blue. When the depth sensor's firmware is updating, the LED will flash red and blue for about a minute then reboot. If the depth sensor LED appears solid red, there is an error. If the LED remains red after restarting the robot, please contact support for assistance.
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** When the Occipital Structure Core depth sensor is starting up, the LED in the depth sensor will flash blue and red for up to 10 seconds. Once the depth sensor is fully online, the LED should be solid blue. When the depth sensor's firmware is updating, the LED will flash red and blue for about a minute then reboot. If the depth sensor LED appears solid red, there is an error. If the LED remains red after restarting the robot, please contact support for assistance.
+{{box op="end"}}
+
+{{box op="start" cssClass="boxed noteBox"}}
 **Important!** There is a laser sensor located in the Occipital Structure Core depth sensor, above the right side of Misty's display screen. Never stare directly into the laser. Do not directly touch the laser or remove the protective cover over the laser. Oils on your finger can cause the light to disperse into your eyes and increase the risk of physical damage. ![Misty laser warning](/assets/images/do_not_touch_laser.jpg)
+{{box op="end"}}
 
 Now that you've put your robot together, you can set up Misty's internet connection with the [Misty App](../../../tools-&-apps/mobile/misty-app/).
 
 
 ## Cleaning the Time-of-Flight Sensors
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note**: This is **not** something you need to do with your robot on arrival or perhaps ever, but it's good to know about, just in case.
+{{box op="end"}}
 
 A Misty I Developer Edition Prototype robot has a total of four time-of-flight sensors: three on the front and one on the back. These sensors obtain distance data for objects in Misty's environment and allow her to avoid obstacles as she moves. ![time-of-flight sensors](/assets/images/tof_sensors.jpg)
 
@@ -119,8 +134,9 @@ We recommend powering up Misty on the floor, if possible, to avoid the risk of d
 3. Misty's eyes should appear on screen, beginning in a closed state. The eyes gradually open more fully. ![closed eyes](/assets/images/blink.jpg)
 4. When the eyes appear fully open, Misty is done booting up. This should take a little more than a minute. **Important! If after a few minutes, Misty's eyes still do not appear fully open, contact technical support for assistance.**  ![fully open eyes](/assets/images/open.jpg)
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** If you want to charge the robot while it’s turned on, you’ll need to **first** let the robot fully boot up, **then** plug the power adaptor into the robot’s back.
-
+{{box op="end"}}
 
 ### Restarting Misty
 
@@ -129,15 +145,21 @@ We recommend powering up Misty on the floor, if possible, to avoid the risk of d
 3. Turn on the power switch on Misty's back again.
 4. Once you see the blue LED light and Misty's eyes fully re-open, you're ready.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** If Misty is charging during a restart, after she has fully restarted you must unplug the adaptor from the power port on her back, then plug it back in again for charging to continue.
+{{box op="end"}}
 
 ### Turning Misty Off
 
 Just turn off the power switch on Misty’s back.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** There is no graceful shutdown at this time. When Misty’s battery gets below about 7 volts she abruptly powers down.
+{{box op="end"}}
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** At this time, critical updates of Misty's underlying operating system platforms (e.g. Windows IoT Core) may occur without warning. If you see an image of gears on Misty's screen, be aware that she is going through a system update.
+{{box op="end"}}
 
 ## System Updates
 

--- a/src/content/misty-ii/javascript-sdk/api-reference.md
+++ b/src/content/misty-ii/javascript-sdk/api-reference.md
@@ -38,9 +38,12 @@ misty.DeleteAudio("DeleteMe.wav");
 ```
 
 ### misty.DeleteImage
+
 Enables you to remove an image file from Misty that you have previously saved to her storage.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** You can only delete image files that you have previously saved to Misty's storage. You cannot remove Misty's default system image files.
+{{box op="end"}}
 
 ```javascript
 // Syntax
@@ -84,13 +87,16 @@ misty.DeleteVideo("MyVid.mp4");
 
 Obtains a system or user-uploaded audio file currently stored on Misty.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore (in this case, `_GetAudioFile()`). For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
-
 ```javascript
 misty.GetAudioFile(string fileName, [string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
-Arguments  
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore (in this case, `_GetAudioFile()`). For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
+Arguments
+
 * fileName (string) - The name of the audio file to get, including its file type extension.
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If blank, the system passes data into the default `_GetAudioFile()` callback function.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`.
@@ -117,12 +123,14 @@ function _GetAudioFile(data)
 
 Lists all audio files (default system files and user-added files) currently stored on Misty.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
-
 ```javascript
 // Syntax
 misty.GetAudioList([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -148,9 +156,12 @@ Returns
    * SystemAsset (boolean) - If `true`, the file is one of Misty's default system audio files. If `false`, a user created the file.
 
 ### misty.GetImage
+
 Obtains a system or user-uploaded image file currently stored on Misty.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the onrobot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 ```javascript
 misty.GetImage(string fileName, [string callback], [bool base64 = true], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
@@ -186,14 +197,17 @@ Returns
   - Base64 (string) - A string containing the Base64-encoded image data.
 
 ### misty.GetImageList
-Obtains a list of the images stored on Misty.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+Obtains a list of the images stored on Misty.
 
 ```javascript
 // Syntax
 misty.GetImageList([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs])
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -433,7 +447,9 @@ Obtains a list of the most recent messages Misty has received through the univer
 misty.GetSerialSensorValues([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_GetSerialSensorValues()`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -541,7 +557,9 @@ misty.AddReturnProperty("EventName", "DistanceInMeters");
 
 Register to receive messages with live event data from one of Misty's sensors. 
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Sensor Event Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#sensor-event-callbacks).
+{{box op="end"}}
 
 ```javascript
 // Syntax
@@ -599,7 +617,9 @@ Returns
 
 Creates an event that calls a callback function after a specified period of time. For an example of using this function, see the [Timer Event tutorial](../../../misty-ii/javascript-sdk/tutorials/#timer-events).
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Timed or Triggered Event Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#timed-or-triggered-event-callbacks).
+{{box op="end"}}
 
 ```javascript
 // Syntax
@@ -628,7 +648,9 @@ Returns
 
 Creates a listener for custom user events. You can trigger a custom event by making a REST call to the [TriggerSkillEvent](../../../misty-ii/rest-api/api-reference/#triggerskillevent) endpoint, or by issuing a [`TriggerEvent`](../../../misty-ii/javascript-sdk/api-reference/#misty-triggerevent) command from another JavaScript or .NET skill that is running at the same time.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Timed or Triggered Event Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#timed-or-triggered-event-callbacks).
+{{box op="end"}}
 
 ```javascript
 // Syntax
@@ -927,7 +949,9 @@ misty.GetBlinkSettings([string callback], [string callbackRule = "synchronous"],
 **Note:** This command is currently in **Beta**, and related hardware, firmware, or software is still under development. Feel free to use this command, but recognize that it may behave unpredictably at this time.
 {{box op="end"}}
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_GetBlinkSettings()`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -1400,7 +1424,7 @@ Pauses speech.
 
 **`<break>` Supported Attributes**
 
-**Note:** Use one of these attributes, but not both.
+Use **either** the `time` or `strength` attribute, but not both.
 
 - `time`: milliseconds of pause
 - `strength`: 
@@ -3222,14 +3246,17 @@ misty.ForgetFaces("John");
 ### misty.GetKnownFaces
 Obtains a list of the names of faces on which Misty has been successfully trained.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
-
 ```javascript
 // Syntax
 misty.GetKnownFaces([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
 * skillToCall (string) - Optional. The unique id of a skill to trigger for the callback, instead of calling back into the same skill.
@@ -3790,7 +3817,9 @@ Publishes a string to subscribers of the `SkillData` named object. Use this meth
 
 You can think of `misty.Debug()` as the Misty version of `console.log()`. When you use Skill Runner to run a skill, the web page subscribes to the `SkillData` named object via Misty's WebSocket connection. This allows Misty to print error messages, debug messages, and other skill data to the console in your web browser. Use `misty.Debug()` to print your own messages to the console.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Data you pass into the `misty.Debug()` message must be a string. To send a data object, you can serialize your data into a string and parse it out on the client side of the `SkillData` subscription. If `BroadcastMode` is set to `off` in the meta file for a skill, the skill does not publish debug data.
+{{box op="end"}}
 
 ```javascript
 // Syntax
@@ -3840,7 +3869,9 @@ Returns
 
 Obtains a list of the skills currently running on Misty.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 ```javascript
 //Syntax
@@ -4064,9 +4095,12 @@ Describes whether the audio service running on Misty's 820 processor is currentl
 // Syntax
 misty.AudioServiceEnabled([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_AudioServiceEnabled()`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
 
 For more information about enabling and disabling the audio service, see the [`DisableAudioService`](./#misty-disableaudioservice) command description.
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_AudioServiceEnabled()`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -4186,14 +4220,13 @@ Returns
 
 Force-clears an error message from Misty’s display. 
 
-**Note:** This command is provided as a convenience. You should not typically need to call `misty.ClearDisplayText()`.
-
 ```javascript
 // Syntax
 misty.ClearDisplayText ([int prePauseMs], [int postPauseMs])
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -4206,14 +4239,13 @@ misty.ClearDisplayText();
 
 Force-clears an error message from Misty’s display. 
 
-**Note:** This command is provided as a convenience. You should not typically need to call `misty.ClearErrorText()`.
-
 ```javascript
 // Syntax
 misty.ClearErrorText ([int prePauseMs], [int postPauseMs])
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -4511,15 +4543,17 @@ misty.ForgetWifi("MyHomeWifi")
 
 Obtains a list of local WiFi networks and basic information regarding each.
 
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
-
-
 ```javascript
 // Syntax
 misty.GetAvailableWifiNetworks([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
 * skillToCall (string) - Optional. The unique id of a skill to trigger for the callback, instead of calling back into the same skill.
@@ -4542,7 +4576,9 @@ Returns
 
 Obtains Misty's current battery level, along with other information about the battery.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 ```javascript
 // Syntax
@@ -4639,7 +4675,9 @@ Returns
 
 Obtains device-related information for the robot.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 ```javascript
 // Syntax
@@ -4687,9 +4725,12 @@ Returns
    * WindowsOSVersion - The version of Windows IoT Core running on the robot.
 
 ### misty.GetHelp
+
 Obtains information about a specified API command. Calling `misty.GetHelp()` with no parameters returns a list of all the API commands that are available.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 ```javascript
 // Syntax
@@ -4799,7 +4840,9 @@ If the log level is set to `Info`:
 | Error  |    &#x2713;      |&#x2713;             |
 
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -4860,7 +4903,9 @@ Returns
 
 Obtains Misty's list of saved network IDs.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 ```javascript
 // Syntax
@@ -4911,9 +4956,13 @@ Example JSON object for a saved WiFi network:
 
 Obtains information about a specified WebSocket class. Calling `misty.GetWebsocketNames()` without specifying a class returns information about all of Misty’s available WebSocket connections.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** For more detailed information about each of Misty’s WebSocket connections, see [Event Types](../../../misty-ii/robot/sensor-data/).
+{{box op="end"}}
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 ```javascript
 // Syntax

--- a/src/content/misty-ii/javascript-sdk/api-reference.md
+++ b/src/content/misty-ii/javascript-sdk/api-reference.md
@@ -39,16 +39,16 @@ misty.DeleteAudio("DeleteMe.wav");
 
 ### misty.DeleteImage
 
-Enables you to remove an image file from Misty that you have previously saved to her storage.
-
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** You can only delete image files that you have previously saved to Misty's storage. You cannot remove Misty's default system image files.
-{{box op="end"}}
+Removes an image file from Misty's storage.
 
 ```javascript
 // Syntax
 misty.DeleteImage(string fileName, [int prePauseMs], [int postPauseMs]);
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** You can only delete image files that you have previously saved to Misty's storage. You cannot remove Misty's default system image files.
+{{box op="end"}}
 
 Arguments
 
@@ -88,6 +88,7 @@ misty.DeleteVideo("MyVid.mp4");
 Obtains a system or user-uploaded audio file currently stored on Misty.
 
 ```javascript
+// Syntax
 misty.GetAudioFile(string fileName, [string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
@@ -157,15 +158,16 @@ Returns
 
 ### misty.GetImage
 
-Obtains a system or user-uploaded image file currently stored on Misty.
+Obtains a system or user-uploaded image file.
+
+```javascript
+// Syntax
+misty.GetImage(string fileName, [string callback], [bool base64 = true], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
+```
 
 {{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the onrobot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
 {{box op="end"}}
-
-```javascript
-misty.GetImage(string fileName, [string callback], [bool base64 = true], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
-```
 
 Arguments
 
@@ -369,7 +371,7 @@ Returns
 
 ### misty.SaveAudio
 
-Saves an audio file to Misty. Maximum size is 3 MB. Accepts audio files formatted as `.wav`, `.mp3`, `.wma`, and `.aac`.
+Saves an audio file to Misty. Maximum size is 3 MB. Accepts audio files formatted as .wav .mp3, .wma, and .aac.
 
 ```javascript
 // Syntax
@@ -390,18 +392,19 @@ Arguments
 misty.SaveAudio("Filename.wav", "137,80,78,71,13,1...", false, false);
 ```
 
-
 ### misty.SaveImage
-Saves an image to Misty in the form of a base64 string. Optionally, proportionately reduces the size of the saved image.
 
-Valid image file types are .jpg, .jpeg, .gif, and .png. Maximum file size is 3 MB. **Note:** Images can be reduced in size but not enlarged. Because Misty does not adjust the proportions of images, for best results use an image with proportions similar to her screen (480 x 272 pixels).
+Saves an image to Misty. Optionally, proportionately reduces the size of the saved image.
 
 ```javascript
 // Syntax
 misty.SaveImage(string fileName, string data, [int width], [int height], [bool immediatelyApply], [bool overwriteExisting], [int prePauseMs], [int postPauseMs]
 ```
 
+Valid image file types are .jpg, .jpeg, .gif, and .png. Maximum file size is 3 MB. **Note:** Images can be reduced in size but not enlarged. Because Misty does not adjust the proportions of images, for best results use an image with proportions similar to her screen (480 x 272 pixels).
+
 Arguments
+
 * fileName (string) - The name of the image file to save.
 * data (string) - A Base64-encoded string of the image data.
 * width (integer) - Optional. A whole number greater than 0 specifying the desired image width (in pixels). **Important:** To reduce the size of an image you must supply values for both `width` and `height`. Note that if you supply disproportionate values for `width` and `height`, the system uses the proportionately smaller of the two values to resize the image.
@@ -425,7 +428,7 @@ Saves a video to Misty.
 misty.SaveVideo(string fileName, string data, [bool immediatelyApply], [bool overwriteExisting], [int prePauseMs], [int postPauseMs]);
 ```
 
-Accepted video file types are `.mp4` and `.wmv`. Maximum file size is 6 MB
+Accepted video file types are .mp4 and .wmv. Maximum file size is 6 MB
 
 Arguments
 
@@ -461,20 +464,21 @@ Arguments
 
 Returns
 
-- Result (array) - A list of string values, where each value is a message Misty received through the UART serial port on her back. Messages are sequenced in reverse chronological order, with the most recent message being the last value in the array. Data this command returns must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks) for more information.
+* Result (array) - A list of string values, where each value is a message Misty received through the UART serial port on her back. Messages are sequenced in reverse chronological order, with the most recent message being the last value in the array. Data this command returns must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks) for more information.
 
 ### misty.WriteSerial
 
 Sends data to Misty's universal asynchronous receiver-transmitter (UART) serial port. Use this command to send data from Misty to an external device connected to the port.
-
-Note that Misty can also receive data a connected device sends to the UART serial port. To use this data you must subscribe to [`SerialMessage`](../../../misty-ii/robot/sensor-data/#serialmessage) events.
 
 ```javascript
 // Syntax
 misty.WriteSerial(string message, [int prePauseMs], [int postPauseMs])
 ```
 
+Misty can also receive data through the UART serial port. To use this data you must subscribe to [`SerialMessage`](../../../misty-ii/robot/sensor-data/#serialmessage) events.
+
 Arguments
+
 * message (string) - The data Misty sends to the UART serial port, passed as a string value.
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
@@ -519,7 +523,19 @@ Adds an additional return property field for a registered event.
 misty.AddReturnProperty(string eventName, string eventProperty, [int prePauseMs], [int postPauseMs]);
 ```
 
-Use the `misty.AddReturnProperty()` method to add the values of specific properties from an event message to the data object passed to the callback function for the event. When the event callback handles the data object for an event, the data object includes the values of any properties added with `misty.AddReturnProperty()` in an array called `AdditionalResults`.
+Use the `misty.AddReturnProperty()` method to add the values of specific properties from an event message to the data object passed to the callback function for the event. When the event callback handles the data object for an event, that data includes the values of any properties added with `misty.AddReturnProperty()` in an `AdditionalResults` array.
+
+Arguments
+
+* eventName (string) - The name of the event to add a return property field for.
+* eventProperty (string) - The additional property to return.
+* prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
+* postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
+
+```javascript
+// Example
+misty.AddReturnProperty("EventName", "DistanceInMeters");
+```
 
 You can add multiple return properties to the same event. The order of values in the `AdditionalResults` array matches the order in which you added those properties to the event in your skill code. For an example of how this works, see how the following code adds return properties to a `BumpSensor` event:
 
@@ -541,32 +557,21 @@ function _Bumped(data) {
 }
 ```
 
-Arguments
-* eventName (string) - The name of the event to add a return property field for.
-* eventProperty (string) - The additional property to return.
-* prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
-* postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
-
-```javascript
-// Example
-misty.AddReturnProperty("EventName", "DistanceInMeters");
-```
-
-
 ### misty.RegisterEvent
 
-Register to receive messages with live event data from one of Misty's sensors. 
-
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Sensor Event Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#sensor-event-callbacks).
-{{box op="end"}}
+Creates a listener that receives live data from one of Misty's [event types](../../../misty-ii/robot/sensor-data). 
 
 ```javascript
 // Syntax
 misty.RegisterEvent(string eventName, string messageType, int debounce, [bool keepAlive = false], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Sensor Event Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#sensor-event-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * eventName (string) - Sets an event name (of your choice) for the registered event. The name of the callback function is set automatically to be the same as your event name, prefixed with an underscore (`_<eventName>`). 
 * messageType (string) - The name of the data stream to register for events from. Matches the predefined `Type` property value for the data stream as listed [here](../../../misty-ii/robot/sensor-data).
 * debounce (integer) - Sets the frequency in milliseconds with which event data is sent. 
@@ -612,21 +617,23 @@ Returns
 
 * Data sent by the registered event. Event data must be passed into a callback function to be processed and made available for use in your skill. For more information, see [Sensor Event Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#sensor-event-callbacks).
 
-
 ### misty.RegisterTimerEvent
 
-Creates an event that calls a callback function after a specified period of time. For an example of using this function, see the [Timer Event tutorial](../../../misty-ii/javascript-sdk/tutorials/#timer-events).
-
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Timed or Triggered Event Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#timed-or-triggered-event-callbacks).
-{{box op="end"}}
+Creates an event that invokes a callback function after a set duration.
 
 ```javascript
 // Syntax
 misty.RegisterTimerEvent(string eventName, int callbackTimeInMs, [bool keepAlive], [string callbackRule], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+You can use the `misty.RegisterTimerEvent()` method to implement looping behavior patterns, or to trigger logic just once after a set period of time. For an example, see the [Timer Event tutorial](../../../misty-ii/javascript-sdk/tutorials/#timer-events).
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Timed or Triggered Event Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#timed-or-triggered-event-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * eventName (string) - The name for the timer event. Note that the name you give to this timer event determines the name automatically assigned to your related callback function. That is, the system sets the name of the callback function to be the same as this event name, prefixed with an underscore (`_<eventName>`). For example, for an event name of `MyTimerEvent`, your callback function must use the name `_MyTimerEvent`. 
 * callbackTimeInMs (integer) - The amount of time in milliseconds to wait before the system calls the callback function. For example, passing a value of 3000 causes the system to wait 3 seconds.
 * keepAlive (boolean) -  Optional. By default (`false`) this timer event calls your callback only once. If you pass `true`, your callback function is called in a loop, with a frequency determined by `callbackTimeInMs`. To end the loop, call the `misty.UnregisterEvent()` function in your code.
@@ -648,14 +655,14 @@ Returns
 
 Creates a listener for custom user events. You can trigger a custom event by making a REST call to the [TriggerSkillEvent](../../../misty-ii/rest-api/api-reference/#triggerskillevent) endpoint, or by issuing a [`TriggerEvent`](../../../misty-ii/javascript-sdk/api-reference/#misty-triggerevent) command from another JavaScript or .NET skill that is running at the same time.
 
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Timed or Triggered Event Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#timed-or-triggered-event-callbacks).
-{{box op="end"}}
-
 ```javascript
 // Syntax
 misty.RegisterUserEvent(string eventName, [bool keepAlive], [string callbackRule], [string skillToCall], [int prePauseMs], [int postPauseMs])
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Event data must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for this command are given the same name as the correlated event, prefixed with an underscore: `_<eventName>`. For more on handling event data, see [Timed or Triggered Event Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#timed-or-triggered-event-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -686,7 +693,7 @@ Returns
 
 * data (JSON) - User event data. Data from user events must be passed into a callback function to be processed and made available for use in your skill. See [Triggered Event Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#triggered-event-callbacks) for more information. In addition to the custom data sent with with the event, user event messages always include the following key value pairs. These key/value pairs exist at the same level as the custom data sent with the event.
   * Source (string) - The custom name given to the source for this event. You set the value of the `Source` property when you issue a `TriggerSkillEvent` REST request or invoke a `TriggerEvent` command.
-  * EventOriginator (string) - The type of source from which the event originated. This value is `Skill` if the event came from a JavaScript or .NET skill, and it is `REST` if the event came from a call on the `TriggerSkillEvent` endpoint in Misty's REST API.
+  * EventOriginator (string) - The event's origin. This value is `Skill` if the event came from a JavaScript or .NET skill, and it is `REST` if the event came from a call on the `TriggerSkillEvent` endpoint in Misty's REST API.
   * EventName (string) - The name of this event. You set the value of the `EventName` property issue a `TriggerSkillEvent` REST request or invoke a `TriggerEvent` command.
 
 ### misty.TriggerEvent
@@ -707,44 +714,46 @@ Arguments
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used. 
 
-```javascript
-// Example
+Additionally, user-created events pass the following key/value pairs into the event callback, at the same level as the data passed in for the `data` argument:
 
-// For the "broadcasting" skill:
+* Source (string) - The custom name given to the source for this event.
+* EventOriginator (string) - The event's origin. The value of the `EventOriginator` property for all events broadcast with the `TriggerEvent` command is `Skill`.
+* EventName (string) - The name of this event, as defined in the `EventName` property.
+
+```json
+{
+  "Data": "Value", // Data string
+  "EventName": "MyEvent", // Name of the event
+  "EventOriginator": "Skill", // Where the event came from
+  "Source": "Sender" // Event source
+}
+```
+
+This example demonstrates how to broadcast a custom event called `MyEvent`:
+
+```javascript
+// Example "broadcasting" skill:
 misty.Debug("Starting skill: Sender");
 misty.TriggerEvent("MyEvent", "Sender", JSON.stringify({"Data": "Value"}), "");
+```
 
-// For the "listening" skill:
+And this example demonstrates how to register for the custom event in the previous example:
+
+```javascript
+// Example "listening" skill:
 misty.Debug("Starting skill: Listener");
 misty.RegisterUserEvent("MyEvent", true);
 
 function _MyEvent(data) {
-    misty.Debug("Event received: " + data.EventName);
-    misty.Debug(JSON.stringify(data));
+    misty.Debug("Event received: " + data.EventName); // "MyEvent"
+    misty.Debug(JSON.stringify(data)); // event data
     // Do something
-}
-```
-
-In addition to the data you pass with the `data` argument, user-created events pass the following key/value pairs into the callback function associated with the event listener:
-
-* Source (string) - The custom name given to the source for this event.
-* EventOriginator (string) - The type of source from which the event originated. The value of the `EventOriginator` property for all events broadcast with the `TriggerEvent` command is `Skill`.
-* EventName (string) - The name of this event, as defined in the `EventName` property.
-
-In the example above, the data object passed into the `_MyEvent()` callback function includes each of these key/value pairs at the same level as the data passed in for the `data` argument. The full object that the `_MyEvent()` callback receives looks like this:
-
-```json
-{
-  "Data": "Value",
-  "EventName": "MyEvent",
-  "EventOriginator": "Skill",
-  "Source": "Sender"
 }
 ```
 
 ### misty.UnregisterAllEvents
 
-Unregisters from all events for the skill in which this command is called.
+Unregisters all events in the skill from which this command is called.
 
 ```javascript
 // Syntax
@@ -762,7 +771,7 @@ misty.UnregisterAllEvents();
 
 ### misty.UnregisterEvent
 
-Unregisters from a specified event.
+Unregisters a specific event.
 
 ```javascript
 // Syntax
@@ -791,6 +800,7 @@ misty.ChangeLED(int red, int green, int blue, [int prePauseMs], [int postPauseMs
 ```
 
 Arguments
+
 * Red (integer) - A value between 0 and 255 specifying the red RGB color.
 * Green (integer) - A value between 0 and 255 specifying the green RGB color.
 * Blue (integer) - A value between 0 and 255 specifying the blue RGB color.
@@ -806,12 +816,12 @@ misty.ChangeLED(0, 0, 0);
 
 Displays an image on Misty's screen. You can use the [`SaveImage`](../../../misty-ii/rest-api/api-reference/#saveimage) command in Misty's REST API to upload images to Misty.
 
-By default, images you display with the `misty.DisplayImage()` method draw on the `DefaultImageLayer`. To display an image on a custom layer, use the [`misty.DisplayLayerImage()`](./#misty-displaylayerimage) method. For more information about layers, see [Using Misty's Display](../../../misty-ii/robot/misty-ii/#using-misty-39-s-display).
-
 ```javascript
 // Syntax
 misty.DisplayImage(string fileName, [double alpha], [int prePauseMs], [int postPauseMs])
 ```
+
+By default, images you display with the `misty.DisplayImage()` method draw on the `DefaultImageLayer`. To display an image on a custom layer, use the [`misty.DisplayLayerImage()`](./#misty-displaylayerimage) method. For more information about layers, see [Using Misty's Display](../../../misty-ii/robot/misty-ii/#using-misty-39-s-display).
 
 Arguments
 
@@ -999,12 +1009,6 @@ Arguments
 misty.PauseAudio();
 ```
 
-Related Commands
-
-* [`misty.PlayAudio()`](./#misty-playaudio)
-* [`misty.StopAudio()`](./#misty-stopaudio)
-* [`misty.SaveAudio()`](./#misty-saveaudio)
-
 ### misty.PlayAudio
 
 Starts playing one of the audio assets saved to Misty's local storage, **or** starts playing audio from an HTTP, HTTPS, or RTSP URL.
@@ -1040,12 +1044,6 @@ misty.PlayAudio("http://audio.kuer.org:8000/high")
 // Plays an audio file hosted on the web
 misty.PlayAudio("https://ia802609.us.archive.org/9/items/Free_20s_Jazz_Collection/Eubie_Blake-Charleston_Rag_11KHz_64kb.mp3");
 ```
-
-Related Commands
-
-* [`misty.PauseAudio()`](./#misty-pauseaudio)
-* [`misty.StopAudio()`](./#misty-stopaudio)
-* [`misty.SaveAudio()`](./#misty-saveaudio)
 
 ### misty.RemoveBlinkMappings
 
@@ -1526,12 +1524,6 @@ Arguments
 misty.StopAudio();
 ```
 
-Related Commands
-
-* [`misty.PauseAudio()`](./#misty-pauseaudio)
-* [`misty.PlayAudio()`](./#misty-playaudio)
-* [`misty.SaveAudio()`](./#misty-saveaudio)
-
 ### misty.StopSpeaking
 
 Stops Misty speaking the currently playing text-to-speech utterance.
@@ -1603,6 +1595,7 @@ This command is currently in **Alpha**, and related hardware, firmware, or softw
 {{box op="end"}}
 
 Arguments
+
 * method (string) - The [HTTP request method](https://developer.mozilla.org/en-US/docs/web/HTTP/Methods) (e.g. `GET`, `POST`, etc.) indicating the action to perform for the resource.
 * resource (string) - The full Uniform Resource Identifier of the resource, i.e. `"http://soundbible.com/grab.php?id=1949&type=mp3"`.
 * authorizationType (string) - Optional. The authentication type required to access the resource, i.e. `"OAuth 1.0"`, `"OAuth 2.0"`, or `"Bearer Token"`. Use `null` if no authentication is required.
@@ -1624,9 +1617,14 @@ Returns
 
 ## Movement
 
-<!-- misty.Drive --> 
 ### misty.Drive
+
 Drives Misty forward or backward at a specific speed until cancelled. Call `misty.Stop()` to cancel driving. 
+
+```javascript
+// Syntax
+misty.Drive(double linearVelocity, double angularVelocity, [int prePauseMs], [int postPauseMs]);
+```
 
 When using the `misty.Drive()` command, it helps to understand how linear velocity (speed in a straight line) and angular velocity (speed and direction of rotation) work together:
 
@@ -1635,11 +1633,6 @@ When using the `misty.Drive()` command, it helps to understand how linear veloci
 * Linear velocity (0) and angular velocity (-100) = rotating clockwise at full speed.
 * Linear velocity (0) and angular velocity (100) = rotating counter-clockwise at full speed.
 * Linear velocity (non-zero) and angular velocity (non-zero) = Misty drives in a curve.
-
-```javascript
-// Syntax
-misty.Drive(double linearVelocity, double angularVelocity, [int prePauseMs], [int postPauseMs]);
-```
 
 Arguments
 * linearVelocity (double) - A percent value that sets the speed for Misty when she drives in a straight line. Default value range is from -100 (full speed backward) to 100 (full speed forward).
@@ -1718,7 +1711,13 @@ misty.DriveHeading(90, 0.5, 4000, false);
 ```
 
 ### misty.DriveTime
+
 Drives Misty forward or backward at a set speed, with a given rotation, for a specified amount of time.
+
+```javascript
+// Syntax
+misty.DriveTime(double linearVelocity, double angularVelocity, int timeMs, [double degree], [int prePauseMs], [int postPauseMs]);
+```
 
 When using the `misty.DriveTime()` command, it helps to understand how linear velocity (speed in a straight line) and angular velocity (speed and direction of rotation) work together:
 
@@ -1727,11 +1726,6 @@ When using the `misty.DriveTime()` command, it helps to understand how linear ve
 * Linear velocity (0) and angular velocity (-100) = rotating clockwise at full speed.
 * Linear velocity (0) and angular velocity (100) = rotating counter-clockwise at full speed.
 * Linear velocity (non-zero) and angular velocity (non-zero) = Misty drives in a curve.
-
-```javascript
-// Syntax
-misty.DriveTime(double linearVelocity, double angularVelocity, int timeMs, [double degree], [int prePauseMs], [int postPauseMs]);
-```
 
 Arguments
 
@@ -1926,7 +1920,7 @@ misty.MoveArms(0, 0, 100, 100);
 
 Moves one or both of Misty's arms. You can use this command to control both arms simultaneously or one at a time.
 
-```javascriptvascript
+```javascript
 // Syntax
 misty.MoveArmsDegrees(double leftArmPosition, double rightArmPosition, [double leftArmVelocity], [double rightArmvelocity], [double duration], [double prePauseMs], [double postPauseMs]);
 ```
@@ -1963,7 +1957,7 @@ misty.MoveArmsDegrees(0, 0, 100, 100);
 
 Moves one or both of Misty's arms. You can use this command to control both arms simultaneously or one at a time.
 
-```javascriptvascript
+```javascript
 // Syntax
 misty.MoveArmsRadians(double leftArmPosition, double rightArmPosition, [double leftArmVelocity], [double rightArmvelocity], [double duration], [double prePauseMs], [double postPauseMs]);
 ```
@@ -2085,6 +2079,7 @@ misty.MoveHeadRadians(0.5708, 0.5708, 1.5708, 100);
 ```
 
 ### misty.Stop
+
 Stops Misty's movement.
 
 ```javascript
@@ -2093,6 +2088,7 @@ misty.Stop([int prePauseMs], [int postPauseMs]);
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -2165,7 +2161,7 @@ Obtains the occupancy grid data for Misty's currently active map.
 misty.GetMap([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
-This command is not functional with the Misty II Basic Edition
+This command is not functional with the Misty II Basic Edition.
 
 To obtain a valid response from `misty.GetMap()`, Misty must first have successfully generated a map. To change the currently active map, use the [`SetCurrentSlamMap`](../../../misty-ii/rest-api/api-reference/#setcurrentslammap) command in Misty's REST API.
 
@@ -2207,7 +2203,6 @@ Returns
   * OriginY (float) - The distance in meters from the Y value of the occupancy grid origin (0,0) to the Y coordinate of the physical location where Misty started mapping. The X,Y coordinates of Misty's starting point are always at the center of the occupancy grid. To convert this value to a Y coordinate on the occupancy grid, use the formula 0 - (`originY` / `metersPerCell`). Round the result to the nearest whole number. 
   * Size (integer) - The total number of map cells represented in the grid array. Multiply this number by the value of meters per cell to calculate the area of the map in square meters.
   * Width (integer) - The width of the occupancy grid matrix (in number of cells). 
-
 
 ### misty.GetCurrentSlamMap
 
@@ -2274,7 +2269,7 @@ Arguments
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
 ```javascript
-// Syntax
+// Example
 misty.GetHazardSettings();
 
 function _GetHazardSettings(data) {
@@ -2283,6 +2278,7 @@ function _GetHazardSettings(data) {
 ```
 
 Returns
+
 * Result (object) - Describes the current hazards system settings for Misty's time-of-flight and bump sensors. Includes the following key/value pairs:
   * BumpSensors (array) - An array of objects that describe whether each bump sensor is enabled or disabled. Each object in the `bumpSensors` array includes the following key/value pairs:
     * Enabled (boolean) - Hazards are enabled for this bump sensor if `true`, and are disabled if `false`.
@@ -2300,7 +2296,7 @@ Obtains the current exposure and gain settings for the infrared cameras in the O
 misty.GetSlamIrExposureAndGain([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
-This command is not functional with the Misty II Basic Edition
+This command is not functional with the Misty II Basic Edition.
 
 {{box op="start" cssClass="boxed noteBox"}}
 **Note:** Misty does not return valid values for exposure and gain if you invoke this command when the SLAM system is not streaming. To start SLAM streaming, issue a [`StartSlamStreaming`](../../../misty-ii/javascript-sdk/api-reference/#misty-startslamstreaming) command.
@@ -2508,6 +2504,7 @@ function _GetSlamStatus(data) {
 ```
 
 Returns
+
 * Result (object) - A data object with the following key-value pairs. **Note:** With Misty's on-robot JavaScript API, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks) for more information.
   * `Status` (int) - Number that describes the current status of the SLAM system. This number updates with information from the `SensorStatus` and `RunMode` fields, as well as with other events that occur during a SLAM session. Note that this number represents several status codes simultaneously. You can convert this number to a binary value to see whether the bit field for a given status code is on (`1`) or off (`0`). As an example, the status code `33028` converts to a binary value of `1000000100000100`. In this binary value, the 3rd, 9th, and 16th bits are flipped. Those bits correspond to the status codes for `Exploring`, `LostPose`, and `Streaming`, respectively. (Note that the system also returns the string fields for all current status codes to the `StatusList` array that comes back with a `GetSlamStatus` response.) The following hexadecimal values correspond to bit fields for each possible status code:
     * 0x0000: `Uninitialized` - The SLAM system is not yet initialized.
@@ -2665,7 +2662,7 @@ misty.ResetSlam();
 
 ### misty.SetCurrentSlamMap
 
-Sets a map to be Misty's currently active map for tracking and relocalization.
+Sets a map to be the active map for tracking and relocalization.
 
 ```javascript
 // Syntax
@@ -2676,7 +2673,7 @@ This command is not functional with the Misty II Basic Edition.
 
 Arguments
 
-* key (string) - The unique `key` of the map to make currently active. **Note:** This command does not work when passed the value for the `name` associated with a map.
+* key (string) - The unique `key` of the map to make active. **Note:** This command does not work when passed the value for the `name` associated with a map.
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -2810,9 +2807,11 @@ Opens the data stream from the Occipital Structure Core depth sensor, so you can
 misty.StartSlamStreaming([int prePauseMs], [int postPauseMs]);
 ```
 
-This command is not functional with the Misty II Basic Editi
+This command is not functional with the Misty II Basic Edition.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Important!** Always use `misty.StopSlamStreaming()` to close the depth sensor data stream after sending commands that use Misty's Occipital Structure Core depth sensor. Calling `misty.StopSlamStreaming()` turns off the laser in the depth sensor and lowers Misty's power consumption.
+{{box op="end"}}
 
 Arguments
 
@@ -2857,7 +2856,7 @@ Stops Misty locating the docking station.
 misty.StopLocatingDockingStation([int stopStreamingTimeout], [int disableIrTimeout], [int prePauseMs], [int postPauseMs])
 ```
 
-This command is not functional with the Misty II Basic Editi
+This command is not functional with the Misty II Basic Edition.
 
 For more information about locating the docking station, see the documentation for the [`StartLocatingDockingStation`](./#misty-startlocatingdockingstation) command and the [`ChargerPoseMessage`](../../../misty-ii/robot/sensor-data/#chargerposemessage) event type.
 
@@ -2956,7 +2955,7 @@ Provides the current distance of objects from Misty’s Occipital Structure Core
 misty.TakeDepthPicture([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
-This command is not functional with the Misty II Basic Edition
+This command is not functional with the Misty II Basic Edition.
 
 {{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_TakeDepthPicture()`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
@@ -3018,13 +3017,13 @@ function _TakeFisheyePicture(data) {
 
 Returns
 
-- Result (object) -  An object containing image data and meta information. With Misty's on-robot JavaScript API, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks) for more information.
-  - Base64 (string) - A string containing the Base64-encoded image data.
-  - ContentType (string) - The type and format of the image returned. For pictures you take with the fisheye camera, this is `image/png`.
-  - Height (integer) - The height of the picture in pixels.
-  - Name (string) - The name of the picture. For pictures you take with the fisheye camera, this value is `OccipitalVisibleImage`.
-  - Width (integer) - The width of the picture in pixels.
-  - SystemAsset (bool) - Whether the image is a one of Misty's default system assets. For pictures you take with Misty's fisheye camera, this value is `false`.
+* Result (object) -  An object containing image data and meta information. With Misty's on-robot JavaScript API, data returned by this command must be passed into a callback function to be processed and made available for use in your skill. See ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks) for more information.
+  * Base64 (string) - A string containing the Base64-encoded image data.
+  * ContentType (string) - The type and format of the image returned. For pictures you take with the fisheye camera, this is `image/png`.
+  * Height (integer) - The height of the picture in pixels.
+  * Name (string) - The name of the picture. For pictures you take with the fisheye camera, this value is `OccipitalVisibleImage`.
+  * Width (integer) - The width of the picture in pixels.
+  * SystemAsset (bool) - Whether the image is a one of Misty's default system assets. For pictures you take with Misty's fisheye camera, this value is `false`.
 
 ### misty.UpdateHazardSettings
 
@@ -3150,7 +3149,6 @@ Misty triggers a [`VoiceRecord`](../../../misty-ii/robot/sensor-data/#voicerecor
 {{box op="start" cssClass="boxed noteBox"}}
 **Note:** This command is currently in **Beta**, and related hardware, firmware, or software is still under development. Feel free to use this command, but recognize that it may behave unpredictably at this time.
 {{box op="end"}}
-
 
 Arguments
 
@@ -3396,12 +3394,12 @@ misty.StartAvStreaming("rtspd:1936", 640, 480);
 
 Initiates Misty's detection of faces in her line of vision. This command assigns each detected face a random ID.
 
-When you are done having Misty detect faces, call `misty.StopFaceDetection()`.
-
 ```javascript
 // Syntax
 misty.StartFaceDetection([int prePauseMs], [int postPauseMs]);
 ```
+
+When you are done having Misty detect faces, call [`misty.StopFaceDetection()`](./#misty-stopfacedetection).
 
 Arguments
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
@@ -3664,6 +3662,7 @@ misty.StopFaceDetection();
 ```
 
 ### misty.StopFaceRecognition
+
 Stops the process of Misty recognizing a face she sees.
 
 ```javascript
@@ -3695,6 +3694,7 @@ Arguments
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
 ### misty.StopRecordingAudio
+
 Directs Misty to stop the current audio recording and saves the recording to the robot under the `fileName` name specified in the call to `misty.StartRecordingAudio()`. Use this command after calling the `misty.StartRecordingAudio()` command. If you do not call `misty.StopRecordingAudio()`, Misty automatically stops recording after 60 seconds.
 
 ```javascript
@@ -3703,6 +3703,7 @@ misty.StopRecordingAudio([int prePauseMs], [int postPauseMs]);
 ```
 
 Arguments
+
 * prePauseMs (integer) - Optional. The length of time in milliseconds to wait before executing this command.
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
@@ -3813,18 +3814,20 @@ misty.CancelSkill("c3f9b33b-d895-48cf-8f15-cdcf5a866bde");
 
 ### misty.Debug
 
-Publishes a string to subscribers of the `SkillData` named object. Use this method to print debug messages to the console in your web browser when you use Skill Runner.
-
-You can think of `misty.Debug()` as the Misty version of `console.log()`. When you use Skill Runner to run a skill, the web page subscribes to the `SkillData` named object via Misty's WebSocket connection. This allows Misty to print error messages, debug messages, and other skill data to the console in your web browser. Use `misty.Debug()` to print your own messages to the console.
-
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** Data you pass into the `misty.Debug()` message must be a string. To send a data object, you can serialize your data into a string and parse it out on the client side of the `SkillData` subscription. If `BroadcastMode` is set to `off` in the meta file for a skill, the skill does not publish debug data.
-{{box op="end"}}
+Publishes a debug message to `SkillData` event listeners.
 
 ```javascript
 // Syntax
 misty.Debug(string data, [int prePauseMs], [int postPauseMs]);
 ```
+
+{{box op="start" cssClass="boxed tipBox"}}
+**Tip:** When you run a skill with the [Skill Runner](http://sdk.mistyrobotics.com/skill-runner/) tool, the web page subscribes to the `SkillData` event type via Misty's WebSocket server. This allows Misty to print error messages, debug messages, and other skill data to the console in your web browser. Use `misty.Debug()` to print your own messages to the console.
+{{box op="end"}}
+
+{{box op="start" cssClass="boxed tipBox"}}
+**Tip:** Data you pass in to the `misty.Debug()` message must be a string. To send a data object, you can serialize your data into a string and parse it out on the client side of the `SkillData` subscription. If `BroadcastMode` is set to `off` in the meta file for a skill, the skill does not publish debug data.
+{{box op="end"}}
 
 Arguments
 
@@ -3864,19 +3867,18 @@ Returns
 
 * value (string, boolean, integer, or double) - The data associated with the specified key.
 
-
 ### misty.GetRunningSkills
 
 Obtains a list of the skills currently running on Misty.
-
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
-{{box op="end"}}
 
 ```javascript
 //Syntax
 misty.GetRunningSkills([string callback], [string callbackRule], [string skillToCall], [int prePauseMs], [int postPauseMs])
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With local skills, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -3939,6 +3941,7 @@ misty.Pause(int prePauseMs)
 ```
 
 Arguments
+
 * prePauseMs (integer) - The duration in milliseconds to pause skill execution.
 
 ```javascript
@@ -3948,14 +3951,14 @@ misty.Pause(1000);
 
 ### misty.Publish
 
-Writes data to the robot's internal log.
-
-Note that `misty.Publish()` writes data to the robot's internal log file, even when called in a skill with the value of `WriteToLog` set to `False` in its meta file. You can use the Command Center to download your robot's log files, or send a GET request to the REST endpoint for the [`GetLogFile`](../../../misty-ii/rest-api/api-reference/#getlogfile) command.
+Writes a message to Misty's log file.
 
 ```javascript
 // Syntax
 misty.Publish(string name, string data)
 ```
+
+The `misty.Publish()` method writes data to the robot's internal log file, even when called in a skill with the value of `WriteToLog` set to `False` in its meta file. You can use the Command Center to download your robot's log files, or send a GET request to the REST endpoint for the [`GetLogFile`](../../../misty-ii/rest-api/api-reference/#getlogfile) command.
 
 Arguments
 
@@ -3977,6 +3980,7 @@ misty.RandomPause(int minimumDelay, int maximumDelay)
 ```
 
 Arguments
+
 * minimumDelay (integer) - The minimum duration in milliseconds to pause skill execution.
 * maximumDelay (integer) - The maximum duration in milliseconds to pause skill execution. 
 
@@ -3984,8 +3988,6 @@ Arguments
 // Example
 misty.RandomPause(1000, 2000);
 ```
-
-
 ### misty.Remove
 
 Removes data that has been saved to the robot under a specific key with the `misty.Set()` method. 
@@ -4215,7 +4217,7 @@ Returns
 ### misty.ClearDisplayText
 
 {{box op="start" cssClass="boxed warningBox"}}
-**Deprecation Notice:** This command has been deprecated in favor of [`misty.ClearErrorText()`](./#misty-clearerrortext) and will be removed from Misty's JavaScript API in a future release.
+**Deprecation Notice:** This command has been deprecated and will be removed from Misty's JavaScript API in a future release. Use [`misty.ClearErrorText()`](./#misty-clearerrortext) instead.
 {{box op="end"}}
 
 Force-clears an error message from Misty’s display. 
@@ -4279,6 +4281,7 @@ misty.ConnectToSavedWifi("MyHomeWifi")
 Disables the audio service running on Misty's 820 processor.
 
 ```javascript
+// Syntax
 misty.DisableAudioService([int prePauseMs], [int postPauseMs]);
 ```
 
@@ -4347,6 +4350,7 @@ Arguments
 Disables the camera service running on Misty's 820 processor.
 
 ```javascript
+// Syntax
 misty.DisableCameraService([int prePauseMs], [int postPauseMs]);
 ```
 
@@ -4394,6 +4398,7 @@ Arguments
 Disables the SLAM service running on Misty's 820 processor.
 
 ```javascript
+// Syntax
 misty.DisableSlamService([int prePauseMs], [int postPauseMs]);
 ```
 
@@ -4576,16 +4581,17 @@ Returns
 
 Obtains Misty's current battery level, along with other information about the battery.
 
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
-{{box op="end"}}
-
 ```javascript
 // Syntax
 misty.GetBatteryLevel([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
 * skillToCall (string) - Optional. The unique id of a skill to trigger for the callback, instead of calling back into the same skill.
@@ -4627,15 +4633,14 @@ Returns
 
 Obtains current properties and settings for Misty's 4K camera.
 
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore (in this case, `_GetCameraData()`). For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
-
-{{box op="end"}}
-
 ```javascript
 // Syntax
 misty.GetCameraData([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore (in this case, `_GetCameraData()`). For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -4675,14 +4680,14 @@ Returns
 
 Obtains device-related information for the robot.
 
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
-{{box op="end"}}
-
 ```javascript
 // Syntax
 misty.GetDeviceInformation([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -4726,18 +4731,19 @@ Returns
 
 ### misty.GetHelp
 
-Obtains information about a specified API command. Calling `misty.GetHelp()` with no parameters returns a list of all the API commands that are available.
-
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
-{{box op="end"}}
+Obtains information about a specified API command. Calling `misty.GetHelp()` with no arguments returns a list of all the API commands that are available.
 
 ```javascript
 // Syntax
 misty.GetHelp([string endpointName], [string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * endpointName (string) - Optional. A command in `"Api.<COMMAND>"` format eg: `"Api.GetAudioList"`. If no command name is specified, calling `misty.GetHelp()` returns a list of all  API commands.
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, the default callback function (`<_CommandName>`) is called.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
@@ -4756,22 +4762,25 @@ Returns
 
 ### misty.GetLogFile
 
-Obtains log file data.
+Gets data from Misty's logs.
 
 Pulls up to 3MB of the most recent log data from log files up to 14 days old. Log data returns in ascending order by date and time. If all log data exceeds 3MB, the oldest entry returned may be truncated.
-
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** Misty stores log files only for the most recent 14 day period. Log files from before this period are automatically cleared from the robot's local storage.
-{{box op="end"}}
-
-With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_GetLogFile()`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
 
 ```javascript
 // Syntax
 misty.GetLogFile([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Misty stores log files only for the most recent 14 day period. Log files from before this period are automatically cleared from the robot's local storage.
+{{box op="end"}}
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_GetLogFile()`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
+
 Arguments
+
 * callback (string) - Optional. The name of the callback function to call when the data returned by this command is ready. If empty, results are passed into the default `_GetLogFile()` callback function.
 * callbackRule (string) - Optional. The callback rule for this command. Available callback rules are `"synchronous"`, `"override"`, and `"abort"`. Defaults to `"synchronous"`. For a description of callback rules, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
 * skillToCall (string) - Optional. The unique id of a skill to trigger for the callback, instead of calling back into the same skill.
@@ -4794,7 +4803,7 @@ Returns
 
 ### misty.GetLogLevel
 
-Obtains the current local and remote log level.
+Obtains the current local and remote log levels.
 
 ```javascript
 // Syntax
@@ -4903,14 +4912,14 @@ Returns
 
 Obtains Misty's list of saved network IDs.
 
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
-{{box op="end"}}
-
 ```javascript
 // Syntax
 misty.GetSavedWifiNetworks([string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
+{{box op="end"}}
 
 Arguments
 
@@ -4956,6 +4965,11 @@ Example JSON object for a saved WiFi network:
 
 Obtains information about a specified WebSocket class. Calling `misty.GetWebsocketNames()` without specifying a class returns information about all of Misty’s available WebSocket connections.
 
+```javascript
+// Syntax
+misty.GetSavedWifiNetworks([string websocketClass], [string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
+```
+
 {{box op="start" cssClass="boxed noteBox"}}
 **Note:** For more detailed information about each of Misty’s WebSocket connections, see [Event Types](../../../misty-ii/robot/sensor-data/).
 {{box op="end"}}
@@ -4963,11 +4977,6 @@ Obtains information about a specified WebSocket class. Calling `misty.GetWebsock
 {{box op="start" cssClass="boxed noteBox"}}
 **Note:** With the on-robot JavaScript API, data returned by this and other "Get" type commands must be passed into a callback function to be processed and made available for use in your skill. By default, callback functions for "Get" type commands are given the same name as the correlated command, prefixed with an underscore: `_<COMMAND>`. For more on handling data returned by "Get" type commands, see ["Get" Data Callbacks](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#-quot-get-quot-data-callbacks).
 {{box op="end"}}
-
-```javascript
-// Syntax
-misty.GetSavedWifiNetworks([string websocketClass], [string callback], [string callbackRule = "synchronous"], [string skillToCall], [int prePauseMs], [int postPauseMs]);
-```
 
 Parameters
 
@@ -5051,6 +5060,7 @@ Arguments
 Restarts Misty's 410 or 820 processor.
 
 ```javascript
+// Syntax
 misty.RestartRobot([bool core], [bool sensoryServices], [int prePauseMs], [int postPauseMs]);
 ```
 
@@ -5062,13 +5072,14 @@ Arguments
 * postPauseMs (integer) - Optional. The length of time in milliseconds to wait between executing this command and executing the next command in the skill. If no command follows this command, `postPauseMs` is not used.
 
 ```javascript
-misty.RestartRobot(false, true);
+// Example
+// Restarts the 410 and the 820
+misty.RestartRobot(true, true);
 ```
 
 ### misty.SetDefaultVolume
 
 Sets the default volume of Misty's speakers for audio playback and onboard text-to-speech.
-
 
 ```javascript
 // Syntax
@@ -5093,6 +5104,11 @@ misty.SetDefaultVolume(100);
 ### misty.SetLogLevel
 
 Sets Misty's local and remote logging levels. Use this method to determine which log message types the system writes to the local log file and to the remote Misty Robotics logging database.
+
+```javascript
+// Syntax
+misty.SetLogLevel(string localLogLevel, string remoteLogLevel, [int prePauseMs], [int postPauseMs]);
+```
 
 Changing the log level applies a filter on the type of message the system writes to a given location. Log message types include:
 
@@ -5146,12 +5162,8 @@ If the log level is set to `Info`:
 | Warn   |          |              |
 | Error  |    &#x2713;      |&#x2713;             |
 
-```javascript
-// Syntax
-misty.SetLogLevel(string localLogLevel, string remoteLogLevel, [int prePauseMs], [int postPauseMs]);
-```
-
 Arguments
+
 * localLogLevel (string) - The level to set for Misty's local logs. Accepts `Debug`, `Info`, `Warn`, `Error`, or `None`.
 * remoteLogLevel (string) - The level to set for Misty's remote logs. Accepts `Debug`, `Info`, `Warn`, `Error`, or `None`.
 * prePause (integer) - Optional. The length of time in milliseconds to wait before executing this command.
@@ -5317,14 +5329,14 @@ Arguments
 
 Translates a given string and set of arguments to invoke a command from Misty's API.
 
-{{box op="start" cssClass="boxed noteBox"}}
-**Note:** This command is currently in **Alpha**, and related hardware, firmware, or software is still under development. Feel free to use this command, but recognize that it may behave unpredictably at this time.
-{{box op="end"}}
-
 ```javascript
 // Syntax
 misty.ConvertIntentToCommand(string command, [string argument]...);
 ```
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** This command is currently in **Alpha**, and related hardware, firmware, or software is still under development. Feel free to use this command, but recognize that it may behave unpredictably at this time.
+{{box op="end"}}
 
 {{box op="start" cssClass="boxed noteBox"}}
 **Note:** As an alpha feature, the `misty.ConvertIntentToCommand()` method is in active development, and it may not always produce the expected result. You can expect this method to be modified and improved with future updates to Misty's software.

--- a/src/content/misty-ii/javascript-sdk/javascript-skill-architecture.md
+++ b/src/content/misty-ii/javascript-sdk/javascript-skill-architecture.md
@@ -134,7 +134,9 @@ Optionally, you can set up the `misty.RegisterEvent()` method with callback rule
 
 When you declare your event callback function, you must give it a single parameter to store the event data. In your callback function, you can access all of the key/value pairs associated with the event message in the `PropertyParent` object at `<dataParameter>.PropertyTestResults[0].PropertyParent`.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** In JavaScript skills, the key names in event messages are always camel case (for example, `IsContacted` instead of `isContacted`).
+{{box op="end"}}
 
 As an example, the callback function for a basic `BumpedState` event might be:
 
@@ -416,7 +418,7 @@ The system supplies the following types of helper commands to assist you in writ
 
 * **Persistent Data.** To create data that persists across skills, you must use one of the following helper commands to save (set) that data to the robot or to get that data from the robot: `misty.Set()`, `misty.Get()`, `misty.Remove()`, `misty.Keys()`. Persistent data must be saved as one of these types: `string`, `bool`, `int`, or `double`. Alternately, you can serialize your data into a string using `JSON.stringify()` and parse it out again using `JSON.parse()`. Currently, any data saved to the robot this way is not automatically deleted and by default may be used across multiple skills. **Important!** Data stored via the `Set()` command does not persist across a reboot of the robot at this time.
 * **External Data.** Another type of helper command allows your skill to use data from the Internet. The `SendExternalRequest()` command allows you to obtain remote data and optionally save it to the robot and/or use it immediately. See the [External Requests](../../../misty-ii/javascript-sdk/tutorials/#external-requests) tutorial for an example of using this functionality. <!--TODO: Add link to sendexternalrequest tutorial-->
-* **Pausing and Debugging.** There are a few additional helper commands you can use to help with your skill: `misty.Pause()`, `misty.RandomPause()`, `misty.Debug()`, `misty.CancelSkill()`, and `misty.Publish()`. These commands are described in the [On-Robot JavaScript API reference documentation](../../../misty-ii/javascript-sdk/api-reference). Note: An on-robot skill must have `BroadcastMode` set to `Verbose`, `Debug`, or `All` in the meta file for debug statements to be broadcast. By default, debug statements are set to `Off`.
+* **Pausing and Debugging.** There are a few additional helper commands you can use to help with your skill: `misty.Pause()`, `misty.RandomPause()`, `misty.Debug()`, `misty.CancelSkill()`, and `misty.Publish()`. These commands are described in the [On-Robot JavaScript API reference documentation](../../../misty-ii/javascript-sdk/api-reference). **Note:** An on-robot skill must have `BroadcastMode` set to `Verbose`, `Debug`, or `All` in the meta file for debug statements to be broadcast. By default, debug statements are set to `Off`.
 
 ### Skill Management Commands
 
@@ -736,8 +738,12 @@ POST http://<robot-ip-address>/api/skills/cancel
 {}
 ```
 
-**Important!** Skills running on the robot are subject to a default timeout of 5 minutes. After 5 minutes the skill will cancel, even if it is performing actions or waiting on callbacks. You can change this duration by providing a different `TimeoutInSeconds` value in the `meta` file. This value determines how many seconds elapse before the skill cancels. In addition, if a skill is not performing any actions nor waiting on any commands, it will automatically cancel after 5 seconds.
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Skills running on the robot are subject to a default timeout of 5 minutes. After 5 minutes the skill will cancel, even if it is performing actions or waiting on callbacks. You can change this duration by providing a different `TimeoutInSeconds` value in the `meta` file. This value determines how many seconds elapse before the skill cancels. In addition, if a skill is not performing any actions nor waiting on any commands, it will automatically cancel after 5 seconds.
+{{box op="end"}}
 
-It's possible to prevent this automatic cancellation by using an infinite loop in your code, but doing so can cause Misty to continue executing your skill in the background even after the skill times out or is explicitly cancelled. Currently, you can address this by including an additional `ForceCancelSkill` key in the `meta` file for the skill and setting its value to     `true`. When you do this, issuing a `CancelSkill` command forces the skill to cancel via a thrown exception and stops all background execution of the skill.
+It's possible to prevent this automatic cancellation by using an infinite loop in your code, but doing so can cause Misty to continue executing your skill in the background even after the skill times out or is explicitly cancelled. Currently, you can address this by including an additional `ForceCancelSkill` key in the `meta` file for the skill and setting its value to `true`. When you do this, issuing a `CancelSkill` command forces the skill to cancel via a thrown exception and stops all background execution of the skill.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Cancelling a skill that has a `true` value for `ForceCancelSkill` in the `meta` puts Misty into a state where she may not be able to start new skills for up to 30 seconds. We recommend excluding the `ForceCancelSkill` parameter from the `meta` file for skills without infinite running logic, and avoiding this kind logic where possible.
+{{box op="end"}}

--- a/src/content/misty-ii/javascript-sdk/javascript-skill-architecture.md
+++ b/src/content/misty-ii/javascript-sdk/javascript-skill-architecture.md
@@ -128,9 +128,9 @@ misty.RegisterEvent("BumpedState", "BumpSensor", 100, true);
 
 Optionally, you can set up the `misty.RegisterEvent()` method with callback rules and a skill to trigger for the callback, instead of calling back into the same skill. The available callback rules are `Synchronous`, `Override`, and `Abort`.
 
-* `Synchronous` tells the system to run the new callback thread and to continue running any other threads the skill has started.
-* `Override` tells the system to run the new callback thread but to stop running commands on any other threads, including the thread the callback was called within. The system only runs the thread the callback was triggered in once the callback comes back.
-* `Abort` tells the system to ignore the new callback thread if the skill is still doing work on the original thread the callback was called within. For event callbacks, the new callback is ignored until all current processes are finished running, then the event is processed the next time it is sent.
+* `Synchronous` tells the system to run the new callback thread, to and **continue running** any other threads the skill has started.
+* `Override` tells the system to run the new callback thread, but to **stop running** commands on any other threads, including the thread in which the callback was called. The system only runs the thread in which the callback was triggered after the callback returns.
+* `Abort` tells the system to **ignore the new callback thread**, if the skill is still doing work on the original thread in which the callback was called. For event callbacks, the new callback is ignored until all processes in the original thread complete. Then, the event is processed the next time it is sent.
 
 When you declare your event callback function, you must give it a single parameter to store the event data. In your callback function, you can access all of the key/value pairs associated with the event message in the `PropertyParent` object at `<dataParameter>.PropertyTestResults[0].PropertyParent`.
 

--- a/src/content/misty-ii/javascript-sdk/tutorials.md
+++ b/src/content/misty-ii/javascript-sdk/tutorials.md
@@ -206,7 +206,9 @@ Finally, we call another Misty command, `PlayAudio()`, and pass in the random fi
 misty.PlayAudio(randSound);
 ```
 
-Note: All of this logic needs to be contained within `_GetAudioList()` to ensure that it does not run until the audio list has been populated. 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** All of this logic needs to be contained within `_GetAudioList()` to ensure that it does not run until the audio list has been populated.
+{{box op="end"}} 
 
 Save the code file with the name `HelloWorld_PlayAudio.js`. See the documentation on using [Misty Skill Runner](../../../tools-&-apps/web-based-tools/skill-runner) or the REST API to [load your skill data onto Misty and run the skill from the browser](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#loading-amp-running-a-javascript-skill).
 
@@ -804,9 +806,11 @@ function _FaceRecognition(data) {
 }
 ```
 
-Note: Because we designated the GUID for _this_ skill (`HelloWorld_TriggerSkill2.js`) as the skill to call back in the registration call for `FaceRecognition` within our “parent” skill, this skill starts automatically when the event callback is triggered.
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Because we designated the GUID for _this_ skill (`HelloWorld_TriggerSkill2.js`) as the skill to call back in the registration call for `FaceRecognition` within our "parent" skill, this skill starts automatically when the event callback is triggered.
+{{box op="end"}}
 
-Next, define a variable, `label`, to hold the label of the face detected (or “unknown person” if the face was not recognized). You can access this information within `data.AdditionalResults`. 
+Next, define a variable, `label`, to hold the label of the face detected (or `"unknown person"` if the face was not recognized). You can access this information within `data.AdditionalResults`. 
 
 ```javascript
 // Store the name of the detected face
@@ -1295,7 +1299,9 @@ function _BumpSensor(data) {
 
 When this skill runs, Misty retrieves the list of audio clips in her local storage and associates the names of four audio files with unique global variables. She then registers for bump sensor events. Each time an event occurs, Misty determines which bump sensor was pressed and plays the sound associated with that sensor.
 
-**Note:** By default on-robot JavaScript skills timeout after 300 seconds, so this skill automatically stops executing after 5 minutes. This duration can be changed by changing the value of the `TimeoutInSeconds` property in the meta file. 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** By default on-robot JavaScript skills timeout after 300 seconds, so this skill automatically stops executing after 5 minutes. This duration can be changed by changing the value of the `TimeoutInSeconds` property in the meta file.
+{{box op="end"}} 
 
 Save the code file with the name `HelloWorld_BumpSensors.js`. See the documentation on using [Misty Skill Runner](../../../tools-&-apps/web-based-tools/skill-runner) or the REST API to [load your skill data onto Misty and run the skill from the browser](../../../misty-ii/javascript-sdk/javascript-skill-architecture/#loading-amp-running-a-javascript-skill). 
 

--- a/src/content/misty-ii/rest-api/api-reference.md
+++ b/src/content/misty-ii/rest-api/api-reference.md
@@ -168,7 +168,8 @@ Return Values
    * SystemAsset (boolean) - If `true`, the file is one of Misty's default system audio assets. If `false`, a user created the file.
 
 ### GetImage
-Obtains a system or user-uploaded image file currently stored on Misty
+
+Obtains a system or user-uploaded image file.
 
 Endpoint: GET &lt;robot-ip-address&gt;/api/images?FileName=&lt;name-of-image-file.extension&gt;
 
@@ -298,7 +299,7 @@ Return Values
 
 ### SaveAudio
 
-Saves an audio file to Misty. Maximum size is 3 MB. Accepts audio files formatted as `.wav`, `.mp3`, `.wma`, and `.aac`.
+Saves an audio file to Misty. Maximum size is 3 MB. Accepts audio files formatted as .wav, .mp3, .wma, and .aac.
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/audio
 
@@ -428,7 +429,7 @@ Return Values
 
 Sends data to Misty's universal asynchronous receiver-transmitter (UART) serial port. Use this command to send data from Misty to an external device connected to the port.
 
-Note that Misty can also receive data a connected device sends to the UART serial port. To use this data you must subscribe to [`SerialMessage`](../../../misty-ii/robot/sensor-data/#serialmessage) events.
+Misty can also receive data through the UART serial port. To use this data you must subscribe to [`SerialMessage`](../../../misty-ii/robot/sensor-data/#serialmessage) events.
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/serial
 

--- a/src/content/misty-ii/rest-api/api-reference.md
+++ b/src/content/misty-ii/rest-api/api-reference.md
@@ -11,7 +11,9 @@ With the REST API, you can send commands to Misty from a REST client or browser.
 
 To create skills for Misty, you'll need to send commands to Misty and get data back from Misty. To send commands to Misty, you can call the REST API. To get live updating data back from Misty, you'll need to use a [WebSocket connection](../../rest-api/overview#subscribing-amp-unsubscribing-to-a-websocket). You can visit the [REST-API repository on GitHub](https://github.com/MistyCommunity/REST-API) for sample code and tutorials.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Not all of Misty's API is equally complete. You may see some commands labeled "Beta" or "Alpha" because the related hardware, firmware, or software is still under development. Feel free to use these commands, but realize they may behave unpredictably at this time.
+{{box op="end"}}
 
 ## URL & Message Formats
 
@@ -54,9 +56,12 @@ For most GET requests, the value for `result` is the response data from Misty. F
 Misty comes with a set of default images that you can display onscreen and sounds that you can play through her speakers. We encourage you to get creative and use your own image and audio assets in your skills.
 
 ### DeleteAudio
+
 Enables you to remove an audio file from Misty that you have previously uploaded.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** You can only delete audio files that you have previously uploaded to Misty. You cannot remove Misty's default system audio files.
+{{box op="end"}}
 
 Endpoint: DELETE &lt;robot-ip-address&gt;/api/audio
 
@@ -77,7 +82,9 @@ Return Values
 
 Deletes an image file from Misty's storage.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** You can only delete image files that you have previously uploaded to Misty. You cannot remove Misty's default system image files.
+{{box op="end"}}
 
 Endpoint: DELETE &lt;robot-ip-address&gt;/api/images
 
@@ -123,11 +130,14 @@ Return Values
 
 Obtains a system or user-uploaded audio file currently stored on Misty.
 
-Endpoint: GET &lt;robot-ip-address&gt;/api/audio?FileName={name-of-audio-file.extension}
+Endpoint: GET &lt;robot-ip-address&gt;/api/audio?FileName=&lt;name-of-audio-file.extension&gt;
+
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Because GET requests do not include payloads, the query parameters for this request must be included in the URL.
+{{box op="end"}}
 
 Parameters
 
-**Note:** Because GET requests do not include payloads, the parameter for this request must be included in the URL as seen above.
 - FileName (string): The name of the audio file to get, including its file type extension.
 - Base64 (boolean): Optional. Sending a request with `true` returns the audio file data as a downloadable Base64 string. Sending a request with `false` returns the audio file to your browser or REST client. Defaults to `false`.
 
@@ -166,9 +176,12 @@ Example:
 
 `http://<robot-ip-address>/api/images?FileName=happy.png&Base64=false`
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Because GET requests do not contain payloads, the query parameter for this request must be included in the URL.
+{{box op="end"}}
+
 Parameters
 
-**Note:** Because GET requests do not contain payloads, the parameter for this request must be included in the URL as seen above.
 - FileName (string) - The name of the image file to get, including the file type extension.
 - Base64 (boolean) - Optional. Sending a request with `true` returns the image data as a downloadable Base64 string. Sending a request with `false` displays the image in your browser or REST client immediately after the image is taken. Default is `true`.
 
@@ -324,11 +337,14 @@ Saves an image to Misty. Optionally, proportionately reduces the size of the sav
 
 Valid image file types are `.jpg`, `.jpeg`, `.gif`, `.png`. Maximum file size is 3 MB.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Images can be reduced in size but not enlarged. Because Misty does not adjust the proportions of images, for best results use an image with proportions similar to her screen (480 x 272 pixels).
+{{box op="end"}}
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/images
 
 Parameters
+
 * FileName (string) - The name of the image file to upload.
 * Data (string) - The image data, passed as a base64 string. You must either supply a value for `Data` **or** specify a `File` to upload.
 * File (object) - The image file to save to Misty. Valid image file types are `jpg`, `.jpeg`, `.gif`, and `.png`. **Note:** Make sure to set the content-type in the header of the POST call to `multipart/form-data`. Uploading files to Misty this way does not work with JQuery’s AJAX, but does work with XHR (XMLHttpRequest). You must either supply a value for `Data` **or** specify a `File` to upload.
@@ -1227,7 +1243,7 @@ Pauses speech.
 
 **`<break>` Supported Attributes**
 
-**Note:** Use one of these attributes, but not both.
+Use **either** the `time` or `stringth` attribute, but not both.
 
 - `time`: milliseconds of pause
 - `strength`: 
@@ -2537,17 +2553,20 @@ This command is not functional with the Misty II Basic Edition.
 
 Endpoint: GET &lt;robot-ip-address&gt;/api/cameras/fisheye
 
-Parameters
-
-- Base64 (boolean) - Sending a request with `true` returns the image data as a downloadable Base64 string, while sending a request of `false` displays the photo in your browser or REST client immediately after it is taken. Default is `false`. **Note:** Images generated by this command are not saved in Misty's memory. To save an image to your robot for later use, pass `true` for `Base64` to obtain the image data, download the image file, then call `SaveImage` to upload and save the image to Misty.
-
-**Note:** Because GET requests do not contain payloads, the parameter for this request must be included in the URL as seen here:
-
 ```markup
 <robot-ip-address>/api/cameras/fisheye?Base64=false
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Because GET requests do not contain payloads, the query parameters for this request must be included in the URL.
+{{box op="end"}}
+
+Parameters
+
+- Base64 (boolean) - Sending a request with `true` returns the image data as a downloadable Base64 string, while sending a request of `false` displays the photo in your browser or REST client immediately after it is taken. Default is `false`. **Note:** Images generated by this command are not saved in Misty's memory. To save an image to your robot for later use, pass `true` for `Base64` to obtain the image data, download the image file, then call `SaveImage` to upload and save the image to Misty.
+
 Return Values
+
 - Result (object) -  An object containing image data and meta information. This object is only sent if you pass `true` for `Base64`.
     - base64 (string) - A string containing the Base64-encoded image data.
     - contentType (string) - The type and format of the image returned.
@@ -3335,7 +3354,9 @@ Return Values
 ### SaveSkillToRobot
 Uploads a skill to the robot and makes it immediately available for the robot to run.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** To send a file with this request, make sure to set the `content-type` in the header of the `POST` call to `multipart/form-data`.
+{{box op="end"}}
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/skills
 
@@ -3381,8 +3402,6 @@ Return Values
 ### ClearErrorText
 
 Force-clears an error message from Misty’s display. 
-
-**Note:** This command is provided as a convenience. You should not typically need to call `ClearErrorText`.
 
 Endpoint: POST &lt;robot-ip-address&gt;/api/text/error/clear <br>
 **Deprecated Endpoint**: POST &lt;robot-ip-address&gt;/api/text/clear

--- a/src/content/misty-ii/rest-api/tutorials.md
+++ b/src/content/misty-ii/rest-api/tutorials.md
@@ -267,7 +267,9 @@ function openCallback() {
 }
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** You can learn more about `DriveTime` and how the parameters affect Misty’s movement in the API section of this documentation.
+{{box op="end"}}
 
 Pass the URL for the `DriveTime` command along with this `data` object to the `axios.post()` method. Use a `then()` method to handle a successful response and `catch()` to handle any errors.
 
@@ -514,7 +516,9 @@ const you = "<your-name>"
 let onList = false;
 ```
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Avoid hard-coding name values like this in real-world applications of Misty skills. Instead, create a form in the browser where users can type and send their names to Misty.
+{{box op="end"}}
 
 #### Opening a Connection
 
@@ -816,7 +820,9 @@ function _FaceRecognition(data) {
 }
 ```
 
-**Note:** This program does not handle the case where the value of `you` is on the list of known faces, but does not match the face of the person in Misty’s field of vision. This tutorial is designed to introduce the basics of face commands and `FaceRecognition` events, and does not address how to handle issues such as the above. This kind of edge case could be handled in a number of ways. For example, you could have Misty print a message that the face does not match the value stored in `you`, and then command her to learn the new face and assign it a numeric value for `FaceID`. Alternately, you could have Misty start face training and include a form in your .html document to allow the user to pass a new value for `FaceID`. The decision is yours!
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** This program does not handle the case where the value of `you` is on the list of known faces, but does not match the face of the person in Misty’s field of vision. This tutorial is designed to introduce the basics of face commands and `FaceRecognition` events, and does not address how to handle issues such as the above. This kind of edge case could be handled in a number of ways. For example, you could have Misty print a message that the face does not match the value stored in `you`, and then command her to learn the new face and assign it a numeric value for `FaceID`. Alternately, you could have Misty start face training and include a form in your .html document to allow the user to pass a new value for `FaceID`.
+{{box op="end"}}
 
 If a face is recognized, the value of the `"label"` property is the name of the recognized person. In our case, this should also be the string stored in `you`. Inside the `if` statement, write code to print a message to greet the recognized face, unsubscribe from `"FaceRecognition"`, and issue a POST request to the endpoint for the command to `StopFacialRecognition`: `"http://" + ip + "/api/faces/recognition/stop"`.
 

--- a/src/content/tools-&-apps/mobile/misty-app.md
+++ b/src/content/tools-&-apps/mobile/misty-app.md
@@ -10,7 +10,8 @@ order: 1
 The Misty App is a mobile app for Android and iOS devices that you can use to set up Misty's Wi-Fi connection. You can also use the app to drive Misty and see information about her software. You can download the Misty App from the [App Store (iOS)](https://apps.apple.com/us/app/misty-app/id1296946424) or [Google Play (Android)](https://play.google.com/store/apps/details?id=com.mistyrobotics.Companion&hl=en_US).
 
 {{box op="start" cssClass="boxed noteBox"}}
-**Note:** 
+**Note:**
+
 * It's not generally recommended for multiple users to each use a separate instance of the Misty companion app to connect and send commands to a single Misty robot. If more than one person does connect to Misty at the same time, as in a class or group development environment, they will need to take turns sending commands, or Misty may appear to respond unpredictably.
 * When using the Misty companion app, **make sure your phone and Misty are on the same Wi-Fi network**.
 {{box op="end"}}

--- a/src/content/tools-&-apps/web-based-tools/blockly.md
+++ b/src/content/tools-&-apps/web-based-tools/blockly.md
@@ -9,7 +9,9 @@ order: 4
 
 Blockly is a block-based, visual programming language editor that runs in your browser.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** We recommend the following browsers for running Blockly with Misty: Chrome, Safari, Firefox, and Microsoft Edge (latest versions).
+{{box op="end"}}
 
 ![Blockly](/assets/images/blockly_1.png)
 
@@ -31,7 +33,9 @@ The following controls are available on Misty's Blockly editor.
 
 Follow the steps below to set up Blockly with Misty.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** It's not generally recommended for multiple users to each use a separate instance of Blockly to connect with and send commands to a single Misty robot. If more than one person does connect to Misty at the same time, as in a class or group development environment, people will need to take turns sending commands, or Misty may appear to respond unpredictably.
+{{box op="end"}}
 
 **Important!** Blockly does not display the complete collection of Misty’s command blocks until after you establish a Wi-Fi connection between Blockly and your robot. If you notice missing command blocks, follow the steps below to make sure a connection exists between your robot and Blockly.
 
@@ -47,10 +51,14 @@ Follow the steps below to set up Blockly with Misty.
 
 Try the following quick "programs" to start controlling Misty with Blockly.
 
+
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** After clicking **Run**, there may be a short delay before Misty initially reacts. When multiple block commands are run in a row, by default there is no delay between commands. You can use the "Pause" block to add a delay between commands when running multiple commands in a row.
+{{box op="end"}}
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Important!** **Abort** stops the project after the current block completes and before the next block begins; it doesn't stop the actions of the current block.
-
+{{box op="end"}}
 
 ### Change the Color of Misty's LED
 
@@ -59,19 +67,22 @@ Want to change the light behind the logo on Misty's chest? Try this.
 1. Choose the "ChangeLEDColor" block and click to select a color.
 2. Click **Run**.
 
-
 ### Change the Image on Misty's Face
 
 Are Misty's eyes looking a bit tired? Try uploading your own image to Misty's screen. It's a two-part process, but each part is very easy!
 
-_Note: Misty's screen is 480 x 272 pixels in size. Because Misty does not adjust the scaling of images, for best results use an image with proportions similar to this._
+{{box op="start" cssClass="boxed noteBox"}}
+**Note:** Misty's screen is 480 x 272 pixels in size. Because Misty does not adjust the scaling of images, for best results use an image with proportions similar to this.
+{{box op="end"}}
 
 First:
+
 1. Choose the "SaveFileToRobot" block.
 2. Add the "BrowseToImageFile" block. When you click on this block, you can select an image file on your computer to upload onto Misty. Valid image file types are .jpg, .jpeg, .gif, .png. and the maximum file size is 3 MB.
 3. Click **Run**.
 
 Then:
+
 1. Choose the "ChangeDisplayImage" block.
 2. Add the "ListFilesAvailable" block and select your file.
 3. Click **Run**.
@@ -280,15 +291,15 @@ Browse for a file on your computer. Connect this with a "SaveFileToRobot" block 
 Parameters
 * File: When you click on this block, a browse file dialog is displayed to allow for file selection. Valid image file types are .jpg, .jpeg, .gif, .png.
 
-
-
 ## Locomotion Commands
+
 Use these commands to drive Misty forward and backward, straight or in a curve, or stop.
 
+{{box op="start" cssClass="boxed noteBox"}}
 **Note:** Before using any locomotion commands, have Misty on a flat surface with plenty of room to move. It's also a good idea to experiment with small velocity values before getting her going at full speed.
+{{box op="end"}}
 
 ![Misty Blockly - locomotion commands](/assets/images/blockly_locomotion_commands2.png)
-
 
 ### Drive
 Drives Misty forward or backward at a given speed. **Important!** The "Drive" block cannot be the final block in a project. "Drive" **must** be followed by "Stop" or some other block.


### PR DESCRIPTION
This PR makes note, tip, and warning styles consistent across all docs. It also makes the organization of JS API method syntax blocks consistent across Misty I and Misty II docs.